### PR TITLE
Use preemptive scroll detection

### DIFF
--- a/docs/javascripts/fix-embed-focus.js
+++ b/docs/javascripts/fix-embed-focus.js
@@ -1,6 +1,19 @@
-// Scroll to the top after the page has loaded to prevent jumping to the embed element
+// Check and reset scroll position if page has been auto-scrolled to embed
 document.addEventListener("DOMContentLoaded", function () {
-  setTimeout(function () {
-    window.scrollTo(0, 0);
-  }, 250);
+  let checkCount = 0;
+  const maxChecks = 100;
+
+  const checkScrollPosition = function () {
+    if (window.scrollY > 0) {
+      window.scrollTo(0, 0);
+      return;
+    }
+
+    checkCount++;
+    if (checkCount < maxChecks) {
+      setTimeout(checkScrollPosition, 10);
+    }
+  };
+
+  setTimeout(checkScrollPosition, 10);
 });


### PR DESCRIPTION
This PR improves the scroll position resetting strategy for pages with `embed` elements.

Using a fixed threshold like 500 ms for only one time can fail sometimes because the auto scroll to `embed` elements can happen after the page is loaded + 500 ms.

An improved strategy is to use a loop to detect every 10 ms if the scroll position has changed and reset it to top right after, until reaching 1000 ms.