### PR TITLE
Add contributing guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -118,7 +118,7 @@ version 2.1, available at
 <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
 
 For answers to common questions about this code of conduct, see the FAQ at
 <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at <elong0527@gmail.com>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing to rtflite
+
+## Developer workflow
+
+## Maintainer workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,104 @@
 
 ## Developer workflow
 
+First off, [install uv](https://docs.astral.sh/uv/getting-started/installation/).
+rtflite uses uv to manage the Python package development environment.
+
+Clone the repository (if you have no direct access, replace the address with
+your forked repository address):
+
+```bash
+git clone https://github.com/pharmaverse/rtflite.git
+```
+
+Create a dedicated branch:
+
+```bash
+cd rtflite
+git checkout -b my-branch
+```
+
+Restore the environment using
+[uv sync](https://docs.astral.sh/uv/concepts/projects/sync/).
+This will restore the exact versions of Python and dependency packages
+under the project's `.venv/` directory:
+
+```bash
+uv sync
+```
+
+Open the project in VS Code:
+
+```bash
+code rtflite
+```
+
+Make changes to the codebase.
+
+We use pytest for unit testing. To run tests and get an HTML preview of
+code coverage, open the
+[VS Code terminal](https://code.visualstudio.com/docs/terminal/basics):
+
+```bash
+pytest
+pytest tests/specific_test.py
+pytest --cov=rtflite --cov-report=html:docs/coverage/
+```
+
+If your terminal did not activate the virtual environment for some reason
+(with symptoms like not finding pytest commands), activate it manually:
+
+```bash
+source .venv/bin/activate
+```
+
+If you made changes to the `.md` files in the root directory or the
+`.qmd` vignettes under `docs/articles/`, make sure to synchronize them
+for the mkdocs website:
+
+```bash
+sh docs/scripts/sync.sh
+```
+
+To preview the mkdocs website:
+
+```bash
+mkdocs serve
+```
+
+Add, commit, and push to remote, then send a pull request:
+
+```bash
+git add -A
+git commit -m "Your commit message"
+git push origin my-branch
+```
+
 ## Maintainer workflow
+
+Update local uv version:
+
+```bash
+uv self update
+```
+
+Update `uv.lock` file regularly:
+
+```bash
+uv sync --quiet
+uv lock --upgrade
+uv sync
+```
+
+Pin a newer Python version in `.python-version` when appropriate:
+
+```bash
+uv python pin 3.y.z
+```
+
+Publish on PyPI (maintainer token required):
+
+```bash
+uv build
+uv publish
+```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ cd rtflite
 python3 -m pip install -e .
 ```
 
+## Contributing
+
+We welcome contributions to rtflite. Please read the rtflite
+[Contributing Guidelines](https://pharmaverse.github.io/rtflite/contributing/)
+to get started.
+
+All interactions within rtflite repositories and issue trackers should adhere to
+the rtflite [Contributor Code of Conduct](https://github.com/pharmaverse/rtflite/blob/main/CODE_OF_CONDUCT.md).
+
 ## License
 
 This project is licensed under the terms of the MIT license.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,5 @@
+# Contributing to rtflite
+
+## Developer workflow
+
+## Maintainer workflow

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,4 +2,104 @@
 
 ## Developer workflow
 
+First off, [install uv](https://docs.astral.sh/uv/getting-started/installation/).
+rtflite uses uv to manage the Python package development environment.
+
+Clone the repository (if you have no direct access, replace the address with
+your forked repository address):
+
+```bash
+git clone https://github.com/pharmaverse/rtflite.git
+```
+
+Create a dedicated branch:
+
+```bash
+cd rtflite
+git checkout -b my-branch
+```
+
+Restore the environment using
+[uv sync](https://docs.astral.sh/uv/concepts/projects/sync/).
+This will restore the exact versions of Python and dependency packages
+under the project's `.venv/` directory:
+
+```bash
+uv sync
+```
+
+Open the project in VS Code:
+
+```bash
+code rtflite
+```
+
+Make changes to the codebase.
+
+We use pytest for unit testing. To run tests and get an HTML preview of
+code coverage, open the
+[VS Code terminal](https://code.visualstudio.com/docs/terminal/basics):
+
+```bash
+pytest
+pytest tests/specific_test.py
+pytest --cov=rtflite --cov-report=html:docs/coverage/
+```
+
+If your terminal did not activate the virtual environment for some reason
+(with symptoms like not finding pytest commands), activate it manually:
+
+```bash
+source .venv/bin/activate
+```
+
+If you made changes to the `.md` files in the root directory or the
+`.qmd` vignettes under `docs/articles/`, make sure to synchronize them
+for the mkdocs website:
+
+```bash
+sh docs/scripts/sync.sh
+```
+
+To preview the mkdocs website:
+
+```bash
+mkdocs serve
+```
+
+Add, commit, and push to remote, then send a pull request:
+
+```bash
+git add -A
+git commit -m "Your commit message"
+git push origin my-branch
+```
+
 ## Maintainer workflow
+
+Update local uv version:
+
+```bash
+uv self update
+```
+
+Update `uv.lock` file regularly:
+
+```bash
+uv sync --quiet
+uv lock --upgrade
+uv sync
+```
+
+Pin a newer Python version in `.python-version` when appropriate:
+
+```bash
+uv python pin 3.y.z
+```
+
+Publish on PyPI (maintainer token required):
+
+```bash
+uv build
+uv publish
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,15 @@ cd rtflite
 python3 -m pip install -e .
 ```
 
+## Contributing
+
+We welcome contributions to rtflite. Please read the rtflite
+[Contributing Guidelines](https://pharmaverse.github.io/rtflite/contributing/)
+to get started.
+
+All interactions within rtflite repositories and issue trackers should adhere to
+the rtflite [Contributor Code of Conduct](https://github.com/pharmaverse/rtflite/blob/main/CODE_OF_CONDUCT.md).
+
 ## License
 
 This project is licensed under the terms of the MIT license.

--- a/docs/scripts/sync.sh
+++ b/docs/scripts/sync.sh
@@ -38,3 +38,6 @@ awk '{gsub("https://github.com/pharmaverse/rtflite/raw/main/docs/assets/logo.png
 
 # Sync CHANGELOG.md with docs/changelog.md
 cp CHANGELOG.md docs/changelog.md
+
+# Sync CONTRIBUTING.md with docs/contributing.md
+cp CONTRIBUTING.md docs/contributing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
     - String width: reference/strwidth.md
   - Changelog: changelog.md
   - Coverage: coverage/
+  - Contributing: contributing.md
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
Closes #23 

This PR adds a contributing guide (and code of conduct) to make it easier for new developers to understand the development workflow.

The contributing guide will be built and linked on the mkdocs website, while the code of conduct is only a Markdown file in the repo.

They are both linked in `README.md` in the new "contributing" section.