### PR TITLE
enable table footnote and source

### DIFF
--- a/examples/example-footnote.py
+++ b/examples/example-footnote.py
@@ -1,0 +1,24 @@
+### Add table footnote and source
+
+import pandas as pd
+from rtflite import RTFDocument, RTFTitle, RTFPageFooter, RTFPageHeader,RTFFootnote, RTFSource
+
+x = RTFFootnote(text=["footnote 1", "footnote 2"])
+
+def df1():
+    data = {
+        "Column1": ["Data 1.1", "Data 2.1"],
+        "Column2": ["Data 1.2", "Data 2.2"],
+    }
+    return pd.DataFrame(data)
+
+df = RTFDocument(
+        df=df1(), 
+        rtf_title=RTFTitle(text=["title 1", "title 2"]),
+        rtf_page_header=RTFPageHeader(text=["header 1", "header 2"]),
+        rtf_page_footer=RTFPageFooter(text=["footer 1", "footer 2"]),
+        rtf_footnote=RTFFootnote(text=["footnote 1", "footnote 2"]),
+        rtf_source=RTFSource(text=["source 1", "source 2"]),
+    )
+
+df.write_rtf("test.rtf")

--- a/src/rtflite/__init__.py
+++ b/src/rtflite/__init__.py
@@ -1,3 +1,3 @@
 from .convert import LibreOfficeConverter
 from .encode import RTFDocument
-from .input import RTFBody, RTFColumnHeader, RTFPage, RTFTitle, RTFPageHeader, RTFPageFooter
+from .input import RTFBody, RTFColumnHeader, RTFPage, RTFTitle, RTFPageHeader, RTFPageFooter, RTFFootnote, RTFSource

--- a/src/rtflite/encode.py
+++ b/src/rtflite/encode.py
@@ -230,6 +230,30 @@ class RTFDocument(BaseModel):
 
         return output
 
+    def _rtf_footnote_encode(self) -> str:
+        """Convert the RTF footnote into RTF syntax using the Text class."""
+        rtf_attrs = self.rtf_footnote
+
+        if rtf_attrs is None:
+            return None
+        
+        rtf_attrs = rtf_attrs._set_default()    
+        col_total_width = self.rtf_page._set_default().col_width
+        col_widths = Utils._col_widths(rtf_attrs.col_rel_width, col_total_width)
+        return rtf_attrs._encode(rtf_attrs.text, col_widths)
+
+    def _rtf_source_encode(self) -> str:
+        """Convert the RTF source into RTF syntax using the Text class."""
+        rtf_attrs = self.rtf_source
+
+        if rtf_attrs is None:
+            return None
+        
+        rtf_attrs = rtf_attrs._set_default()
+        col_total_width = self.rtf_page._set_default().col_width
+        col_widths = Utils._col_widths(rtf_attrs.col_rel_width, col_total_width)
+        return rtf_attrs._encode(rtf_attrs.text, col_widths)
+    
     def _rtf_body_encode(
         self, df: pd.DataFrame, rtf_attrs: TableAttributes | None
     ) -> MutableSequence[str]:
@@ -364,12 +388,25 @@ class RTFDocument(BaseModel):
         self.rtf_body.border_top = BroadcastValue(
             value=self.rtf_body.border_top, dimension=dim
         ).update_row(0, page_border_top)
-        self.rtf_body.border_bottom = BroadcastValue(
-            value=self.rtf_body.border_bottom, dimension=dim
-        ).update_row(dim[0] - 1, page_border_bottom)
-        self.rtf_body.border_bottom = BroadcastValue(
-            value=self.rtf_body.border_bottom, dimension=dim
-        ).update_row(dim[0] - 1, doc_border_bottom)
+
+        # Bottom border last line update
+        if self.rtf_footnote is not None:
+            self.rtf_footnote = self.rtf_footnote._set_default()
+            self.rtf_footnote.border_bottom = BroadcastValue(
+                value=self.rtf_footnote.border_bottom, dimension=(1,1)
+            ).update_row(0, page_border_bottom[0])
+
+            self.rtf_footnote.border_bottom = BroadcastValue(
+                value=self.rtf_footnote.border_bottom, dimension=(1,1)
+            ).update_row(0, doc_border_bottom[0])
+        else:
+            self.rtf_body.border_bottom = BroadcastValue(
+                value=self.rtf_body.border_bottom, dimension=dim
+            ).update_row(dim[0] - 1, page_border_bottom)
+
+            self.rtf_body.border_bottom = BroadcastValue(
+                value=self.rtf_body.border_bottom, dimension=dim
+            ).update_row(dim[0] - 1, doc_border_bottom)
 
         # Body
         rtf_body = self._rtf_body_encode(df=self.df, rtf_attrs=self.rtf_body)
@@ -389,6 +426,8 @@ class RTFDocument(BaseModel):
                     header for sublist in rtf_column_header for header in sublist
                 ) if rtf_column_header else None,
                 "\n".join(rtf_body),
+                "\n".join(self._rtf_footnote_encode()) if self.rtf_footnote is not None else None,
+                "\n".join(self._rtf_source_encode()) if self.rtf_source is not None else None,
                 "\n\n",
                 "}",
             ] if item is not None]

--- a/src/rtflite/input.py
+++ b/src/rtflite/input.py
@@ -680,16 +680,17 @@ class RTFFootnote(TableAttributes):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    df: str | Sequence[str] | pd.DataFrame | None = Field(
+    text: str | Sequence[str] | None = Field(
         default=None, description="Footnote table"
     )
 
     def __init__(self, **data):
         defaults = {
+            "col_rel_width": 1,
             "border_left": "single",
             "border_right": "single",
-            "border_top": "",
-            "border_bottom": "single",
+            "border_top": "single",
+            "border_bottom": "",
             "border_width": 15,
             "cell_height": 0.15,
             "cell_justification": "c",
@@ -712,9 +713,12 @@ class RTFFootnote(TableAttributes):
         defaults.update(data)
         super().__init__(**defaults)
 
-        # Convert df to DataFrame during initialization
-        if self.df is not None:
-            self.df = BroadcastValue(value=self.df).to_dataframe()
+        # Convert text to DataFrame during initialization
+        if self.text is not None:
+            if isinstance(self.text, Sequence):
+                self.text = "\\line ".join(self.text)
+
+        self.text = BroadcastValue(value=self.text).to_dataframe()
 
     def _set_default(self):
         for attr, value in self.__dict__.items():
@@ -729,16 +733,17 @@ class RTFSource(TableAttributes):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    df: str | Sequence[str] | pd.DataFrame | None = Field(
+    text: str | Sequence[str] | None = Field(
         default=None, description="Data source table"
     )
 
     def __init__(self, **data):
         defaults = {
-            "border_left": "single",
-            "border_right": "single",
+            "col_rel_width": 1,
+            "border_left": "",
+            "border_right": "",
             "border_top": "",
-            "border_bottom": "single",
+            "border_bottom": "",
             "border_width": 15,
             "cell_height": 0.15,
             "cell_justification": "c",
@@ -761,9 +766,12 @@ class RTFSource(TableAttributes):
         defaults.update(data)
         super().__init__(**defaults)
 
-        # Convert df to DataFrame during initialization
-        if self.df is not None:
-            self.df = BroadcastValue(value=self.df).to_dataframe()
+        # Convert text to DataFrame during initialization
+        if self.text is not None:
+            if isinstance(self.text, Sequence):
+                self.text = "\\line ".join(self.text)
+
+        self.text = BroadcastValue(value=self.text).to_dataframe()
 
     def _set_default(self):
         for attr, value in self.__dict__.items():


### PR DESCRIPTION
Enable table footnote and source. 

```
### Add table footnote and source

import pandas as pd
from rtflite import RTFDocument, RTFTitle, RTFPageFooter, RTFPageHeader,RTFFootnote, RTFSource

x = RTFFootnote(text=["footnote 1", "footnote 2"])

def df1():
    data = {
        "Column1": ["Data 1.1", "Data 2.1"],
        "Column2": ["Data 1.2", "Data 2.2"],
    }
    return pd.DataFrame(data)

df = RTFDocument(
        df=df1(), 
        rtf_title=RTFTitle(text=["title 1", "title 2"]),
        rtf_page_header=RTFPageHeader(text=["header 1", "header 2"]),
        rtf_page_footer=RTFPageFooter(text=["footer 1", "footer 2"]),
        rtf_footnote=RTFFootnote(text=["footnote 1", "footnote 2"]),
        rtf_source=RTFSource(text=["source 1", "source 2"]),
    )

df.write_rtf("test.rtf")
```


![image](https://github.com/user-attachments/assets/6b4dd0d6-0a2e-4d7e-b045-fee166c96bd9)
