### PR TITLE
Reorder articles in navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ nav:
       - articles/example-efficacy.md
       - articles/example-ae-summary.md
     - Pagination:
-      - articles/pagination-advanced.md
       - articles/pagination-basic.md
+      - articles/pagination-advanced.md
       - articles/pagination-grouping.md
     - Formatting:
       - articles/formatting-row.md


### PR DESCRIPTION
This PR reorders articles in the mkdocs site navigation so that basic pagination appears before advanced pagination.