### PR TITLE
Use click < 8.2.2 in mkdocs GitHub Actions workflow to avoid directory URL issue

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -35,6 +35,7 @@ jobs:
           pip install mkdocs-material mkdocstrings-python
           pip install pytest pytest-cov
           pip install -e '.[all]'
+          pip install --force-reinstall "click<8.2.2" # Workaround for https://github.com/squidfunk/mkdocs-material/issues/8375
 
       - name: Generate coverage report and deploy mkdocs site
         run: |


### PR DESCRIPTION
This PR updates the mkdocs GitHub Actions workflow to use click < 8.2.2 for avoiding the directory URL issue. The issue and workaround is described in https://github.com/squidfunk/mkdocs-material/issues/8375.

The problem: with click >= 8.2.2, the vignettes under `docs/articles/` will be built into `articles/something.html` instead of the expected `articles/something/index.html`.

This problem changes the relative URL structure between the pages and static assets and will cause, for example, the linked PDFs on these pages to have the wrong URL and result in 404.