### PR TITLE
Install plotnine in mkdocs workflow

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install mkdocs-material mkdocstrings-python markdown-exec[ansi]
+          pip install mkdocs-material mkdocstrings-python markdown-exec[ansi] plotnine
           pip install pytest pytest-cov
           pip install -e '.[all]'
           pip install --force-reinstall "click<8.2.2" # Workaround for https://github.com/squidfunk/mkdocs-material/issues/8375


### PR DESCRIPTION
This is another follow-up to #67.

Any dependencies needed to evaluate the code chunks like plotnine also need to be explicitly installed in the mkdocs GitHub Actions workflow.