### PR TITLE
Include markdown-exec artifacts in mkdocs workflow

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -40,6 +40,10 @@ jobs:
           pip install -e '.[all]'
           pip install --force-reinstall "click<8.2.2" # Workaround for https://github.com/squidfunk/mkdocs-material/issues/8375
 
+      - name: Remove .gitignore entries for markdown-exec artifacts so they are included
+        run: |
+          awk '!/^\/docs\/articles\/(rtf|pdf|images)\/$/' .gitignore > .gitignore.tmp && mv .gitignore.tmp .gitignore
+
       - name: Generate coverage report and deploy mkdocs site
         run: |
           pytest --cov=rtflite --cov-report=html:docs/coverage/


### PR DESCRIPTION
This PR is another follow-up to #67.

The artifacts directories (`docs/articles/rtf/`, `docs/articles/pdf/`, `docs/articles/images/`) generated by markdown-exec are not being copied by mkdocs into the published site when building the site in GitHub Actions, probably due to their presence in `.gitignore`.

This patch tries to remove these rules from `.gitignore` *ad hoc* in the GHA workflow so the directories can be picked up by mkdocs.