### PR TITLE
Do not ignore artifacts directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,3 @@ wheels/
 
 # r2rtf
 Rplots.pdf
-
-# markdown-exec rendered artifacts
-/docs/articles/rtf/
-/docs/articles/pdf/


### PR DESCRIPTION
After #71, the example-figure vignette error is now gone as we track the `docs/articles/images/` again. It's now included in the published site. However, `docs/articles/rtf/` and `docs/articles/pdf/` are still missing in `gh-pages` and not picked up by mkdocs.

Trying to fix this, this PR removes them from `.gitignore`.

Just make sure not commit any of these artifacts into the trunk.