### PR TITLE
Revise mkdocs GHA workflow to make sure artifacts are copied

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -43,4 +43,14 @@ jobs:
       - name: Generate coverage report and deploy mkdocs site
         run: |
           pytest --cov=rtflite --cov-report=html:docs/coverage/
+          # Build the site first to generate all artifacts
+          mkdocs build
+          # Ensure generated artifacts are included
+          if [ -d "docs/articles/rtf" ]; then
+            cp -r docs/articles/rtf site/articles/
+          fi
+          if [ -d "docs/articles/pdf" ]; then
+            cp -r docs/articles/pdf site/articles/
+          fi
+          # Deploy the built site
           mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ wheels/
 
 # r2rtf
 Rplots.pdf
+
+# markdown-exec artifacts
+/docs/articles/rtf/
+/docs/articles/pdf/


### PR DESCRIPTION
This is a follow-up to #72, which didn't solve the `rtf/` and `pdf/` directories not being copied issue.

This GHA workflow change is suggested by Claude:

> The issue was that `mkdocs gh-deploy` wasn't including the dynamically generated RTF and PDF files. The solution:
>
> 1. Build the site first with mkdocs build to trigger markdown-exec and generate all artifacts
> 2. Copy the generated directories (docs/articles/rtf/ and docs/articles/pdf/) to the site output
> 3. Then deploy with `mkdocs gh-deploy --force`