### PR TITLE
Use another approach to switch to Agg backend

### DIFF
--- a/docs/articles/example-figure.md
+++ b/docs/articles/example-figure.md
@@ -14,9 +14,9 @@ This example shows how to create RTF documents with embedded figures using rtfli
 from importlib.resources import files
 
 # Set matplotlib backend for headless environments (GitHub Actions)
-import matplotlib
+import matplotlib.pyplot as plt
 
-matplotlib.use("Agg")
+plt.switch_backend("Agg")
 
 import polars as pl
 from plotnine import aes, geom_histogram, ggplot, labs, theme, theme_minimal


### PR DESCRIPTION
Apparently, #74 didn't work in reality. So instead of using

```python
import matplotlib
matplotlib.use("Agg")
```

to switch matplotlib backend for plotnine, we try to use

```python
import matplotlib.pyplot as plt
plt.switch_backend("Agg")
```

here.