### PR TITLE
Add ttf-mscorefonts-installer to mkdocs GHA workflow

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -30,6 +30,11 @@ jobs:
           restore-keys: |
             mkdocs-material-
 
+      - name: Install ttf-mscorefonts-installer
+        run: |
+          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+          sudo apt-get update && sudo apt-get install ttf-mscorefonts-installer
+
       - name: Install LibreOffice
         run: sudo apt-get update && sudo apt-get install libreoffice --no-install-recommends
 


### PR DESCRIPTION
This PR adds the ttf-mscorefonts-installer to the mkdocs GitHub Actions workflow.

With the proper fonts installed, the PDF output rendered by the workflow for the mkdocs website would look identical to locally rendered PDF.