### PR TITLE
Add ASCII verifier script and fix all non-ASCII characters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ The project follows a **modern service-oriented architecture** with clean separa
 **Always use the service layer for complex operations**:
 
 ```python
-# ✅ Correct: Use service layer
+# CORRECT: Use service layer
 from rtflite.services import RTFEncodingService, TextConversionService
 
 encoding_service = RTFEncodingService()
@@ -180,7 +180,7 @@ converted = encoding_service.convert_text_for_encoding("\\beta", True)
 **Create components directly using Pydantic models**:
 
 ```python
-# ✅ Correct: Direct component creation
+# CORRECT: Direct component creation
 from rtflite import RTFTitle, RTFFootnote, RTFBody
 
 title = RTFTitle(text="Clinical Study Report", text_font_size=[14])
@@ -193,7 +193,7 @@ body = RTFBody(col_rel_width=[2, 1, 1], text_justification=[["l", "c", "c"]])
 **Use the new text conversion interface**:
 
 ```python
-# ✅ Correct: Use new interface
+# CORRECT: Use new interface
 from rtflite.text_conversion import convert_text
 
 result = convert_text("\\alpha + \\beta", enable_conversion=True)
@@ -209,7 +209,7 @@ stats = converter.get_conversion_statistics("\\alpha \\unknown")
 **The encoding engine automatically selects the optimal strategy**:
 
 ```python
-# ✅ The RTFDocument automatically uses the right strategy
+# CORRECT: The RTFDocument automatically uses the right strategy
 doc = RTFDocument(df=data)
 rtf_output = doc.rtf_encode()  # Uses SinglePageStrategy or PaginatedStrategy
 ```
@@ -247,15 +247,15 @@ The project includes Liberation and CrOS fonts for consistent string width calcu
 **Test Architecture Components Independently**:
 
 ```python
-# ✅ Test services independently
+# CORRECT: Test services independently
 from rtflite.services import TextConversionService
 
 def test_text_conversion():
     service = TextConversionService()
     result = service.convert_text_content("\\alpha", True)
-    assert result == "α"
+    assert result == "\u03b1"
 
-# ✅ Test with comprehensive validation
+# CORRECT: Test with comprehensive validation
 def test_conversion_validation():
     service = TextConversionService()
     validation = service.validate_latex_commands("\\alpha \\unknown")
@@ -266,13 +266,13 @@ def test_conversion_validation():
 **Test Integration with Full Documents**:
 
 ```python
-# ✅ Test full RTF pipeline with text conversion
+# CORRECT: Test full RTF pipeline with text conversion
 def test_rtf_integration():
     doc = RTFDocument(df=data, rtf_title=RTFTitle(text="Study: \\alpha"))
     # Enable conversion for footnotes/sources (disabled by default)
     doc.rtf_footnote = RTFFootnote(text="Level: \\alpha = 0.05", text_convert=[[True]])
     rtf_output = doc.rtf_encode()
-    assert "α" in rtf_output
+    assert "\u03b1" in rtf_output
 ```
 
 **Legacy Testing Patterns** (still supported):
@@ -299,7 +299,7 @@ def test_example():
 
 **Key utilities in `tests/utils_snapshot.py`**:
 - `remove_font_table()`: Removes font table sections for comparison
-- `normalize_rtf_borders()`: Handles semantic border equivalence (e.g., `\brdrw15` ≡ `\brdrs\brdrw15`)
+- `normalize_rtf_borders()`: Handles semantic border equivalence (e.g., `\brdrw15` == `\brdrs\brdrw15`)
 - `normalize_rtf_structure()`: Handles page break ordering and whitespace
 - `assert_rtf_equals_semantic()`: Complete semantic RTF comparison
 
@@ -338,26 +338,26 @@ The project includes VSCode workspace settings in `.vscode/`:
 - **Custom Tasks**: `Cmd+Shift+W` keybinding to open RTF files in Word
 - **Recommended Extensions**: Python development tools, formatters, and spell checker
 
-**RTF File Preview**: Click any `.rtf` file in VSCode Explorer → Opens in Microsoft Word for formatted preview
+**RTF File Preview**: Click any `.rtf` file in VSCode Explorer -> Opens in Microsoft Word for formatted preview
 
 .vscode/                           # VSCode workspace settings
-├── settings.json                  # RTF file associations
-├── tasks.json                     # Microsoft Word integration
-└── keybindings.json              # Custom shortcuts
+|-- settings.json                  # RTF file associations
+|-- tasks.json                     # Microsoft Word integration
++-- keybindings.json              # Custom shortcuts
 ```
 
 ### Troubleshooting
 
 **RTF Comparison Failures**: Use semantic comparison instead of exact string matching:
 ```python
-# ❌ This may fail due to whitespace/font differences
+# WRONG: This may fail due to whitespace/font differences
 assert rtf_output == expected
 
-# ✅ Use this for robust RTF comparison
+# CORRECT: Use this for robust RTF comparison
 assert_rtf_equals_semantic(rtf_output, expected, "test_name")
 ```
 
-**R Script Errors**: Ensure R code uses proper `write_rtf()` → `readLines()` → `cat()` chain in test comments
+**R Script Errors**: Ensure R code uses proper `write_rtf()` -> `readLines()` -> `cat()` chain in test comments
 
 **LibreOffice Tests**: Skip with `@pytest.mark.skip` decorator if LibreOffice not available
 
@@ -464,6 +464,43 @@ When updating documentation:
 3. **Focus on rtflite behavior** - Avoid comparing to other tools
 4. **Test examples** - Ensure all code examples work
 5. **Follow Google style** - For docstring formatting
+
+### ASCII-Only Code Policy
+
+**IMPORTANT**: All source code files must contain only ASCII characters to ensure maximum compatibility and portability.
+
+#### Required Practices:
+1. **Use Unicode escape sequences** in strings:
+   - CORRECT: `"\u03b1"` for Greek alpha
+   - WRONG: `"alpha"` (direct Unicode character)
+
+2. **Use ASCII alternatives** for symbols:
+   - CORRECT: `# CORRECT:` or `# [OK]`
+   - WRONG: `# [checkmark]` (emoji/symbols)
+   
+3. **In test assertions**, always use escape sequences:
+   ```python
+   # CORRECT:
+   assert result == "\u03b1 test"
+   
+   # WRONG:
+   assert result == "alpha test"
+   ```
+
+4. **In documentation strings**:
+   - Use descriptive text: "Greek letter alpha"
+   - Or use escape sequences: "\u03b1"
+   - Never use literal Unicode characters
+
+5. **Run verification** before committing:
+   ```bash
+   uv run python scripts/verify_ascii.py
+   ```
+
+#### Exceptions:
+- Auto-generated files (coverage reports, CSS)
+- External data files (if necessary)
+- Files explicitly marked for exclusion
 
 See `DOCUMENTATION_GUIDE.md` for detailed documentation practices.
 

--- a/docs/articles/pagination.md
+++ b/docs/articles/pagination.md
@@ -158,12 +158,12 @@ doc = rtf.RTFDocument(
 
 ```
 RTFDocument
-├── _needs_pagination() → bool
-├── _create_pagination_instance() → (RTFPagination, ContentDistributor)
-├── _rtf_page_break_encode() → str
-├── _apply_pagination_borders() → TableAttributes
-├── _rtf_encode_paginated() → str  # Main paginated encoding
-└── _rtf_body_encode_paginated() → List[str]  # Body-only paginated encoding
+|-- _needs_pagination() -> bool
+|-- _create_pagination_instance() -> (RTFPagination, ContentDistributor)
+|-- _rtf_page_break_encode() -> str
+|-- _apply_pagination_borders() -> TableAttributes
+|-- _rtf_encode_paginated() -> str  # Main paginated encoding
++-- _rtf_body_encode_paginated() -> List[str]  # Body-only paginated encoding
 ```
 
 ### Border application flow

--- a/docs/articles/quickstart.md
+++ b/docs/articles/quickstart.md
@@ -304,8 +304,8 @@ By default, text conversion is enabled for titles and data content, but can be c
 ### Text conversion examples
 
 When `text_convert = True` (default for titles and data):
-- `\\alpha` converts to α
-- `\\beta` converts to β
+- `\\alpha` converts to \u03b1 (Greek alpha)
+- `\\beta` converts to \u03b2 (Greek beta)
 - `a_b` converts to subscript format (a subscript b)
 
 When `text_convert = False`:

--- a/scripts/verify_ascii.py
+++ b/scripts/verify_ascii.py
@@ -1,0 +1,191 @@
+"""ASCII verifier.
+
+Verifies whether all text files in the current directory contain only ASCII characters.
+"""
+
+import os
+import sys
+from typing import FrozenSet, List, Tuple
+
+
+def is_text_file(path: str, n: int | None = None) -> bool:
+    """
+    Classify any file as text or binary.
+
+    Algorithm adopted from "A Fast Method for Identifying Plain Text Files"
+    in zlib (`doc/txtvsbin.txt`).
+
+    Args:
+        path: File path.
+        n: Maximal number of bytes to read. Defaults to file size.
+
+    Returns:
+        True if the file is text, False if binary.
+    """
+    ALLOW: FrozenSet[int] = frozenset([9, 10, 13] + list(range(32, 256)))
+    BLOCK: FrozenSet[int] = frozenset(list(range(0, 7)) + list(range(14, 32)))
+
+    with open(path, "rb") as file:
+        bytecode = bytes(file.read(n or os.path.getsize(path)))
+
+    if not bytecode:
+        return False
+
+    cond1 = any(b in ALLOW for b in bytecode)
+    cond2 = not any(b in BLOCK for b in bytecode)
+
+    return cond1 and cond2
+
+
+def find_non_ascii_lines(filepath: str) -> List[Tuple[int, str, List[int]]]:
+    """
+    Find lines containing non-ASCII characters in a text file.
+
+    Args:
+        filepath: Path to the text file.
+
+    Returns:
+        List of tuples (line_number, line_content, positions) where positions
+        are the character indices of non-ASCII characters in the line.
+    """
+    non_ascii_lines = []
+
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, 1):
+                non_ascii_positions = []
+                for pos, char in enumerate(line):
+                    if ord(char) > 127:
+                        non_ascii_positions.append(pos)
+
+                if non_ascii_positions:
+                    non_ascii_lines.append(
+                        (line_num, line.rstrip("\n"), non_ascii_positions)
+                    )
+    except (UnicodeDecodeError, OSError) as e:
+        # File might not be UTF-8 encoded or readable
+        print(f"Warning: Can't read {filepath}: {e}")
+
+    return non_ascii_lines
+
+
+def highlight_non_ascii(line: str, positions: List[int]) -> str:
+    """
+    Highlight non-ASCII characters in a line.
+
+    Args:
+        line: The line content.
+        positions: Positions of non-ASCII characters.
+
+    Returns:
+        Line with highlighted non-ASCII characters.
+    """
+    result = []
+    for i, char in enumerate(line):
+        if i in positions:
+            # Show the character and its Unicode code point
+            result.append(f"[{repr(char)[1:-1]}:U+{ord(char):04X}]")
+        else:
+            result.append(char)
+    return "".join(result)
+
+
+def scan_directory(root_dir: str) -> None:
+    """
+    Scan directory recursively for text files with non-ASCII characters.
+
+    Args:
+        root_dir: Root directory to scan.
+    """
+    # Directories to skip
+    skip_dirs = {
+        ".git",
+        "__pycache__",
+        "build",
+        "dist",
+        "site",
+        "wheels",
+        ".venv",
+        ".pytest_cache",
+        ".egg-info",
+    }
+
+    files_with_non_ascii = []
+    total_files_scanned = 0
+
+    for dirpath, dirnames, filenames in os.walk(root_dir):
+        # Skip certain directories
+        dirnames[:] = [
+            d for d in dirnames if d not in skip_dirs and not d.endswith(".egg-info")
+        ]
+
+        for filename in filenames:
+            filepath = os.path.join(dirpath, filename)
+
+            # Check if it's a text file
+            if not os.path.isfile(filepath):
+                continue
+
+            try:
+                if is_text_file(filepath):
+                    total_files_scanned += 1
+                    non_ascii_lines = find_non_ascii_lines(filepath)
+
+                    if non_ascii_lines:
+                        # Use relative path for cleaner output
+                        rel_path = os.path.relpath(filepath, root_dir)
+                        files_with_non_ascii.append((rel_path, non_ascii_lines))
+            except Exception as e:
+                print(f"Warning: Could not process {filepath}: {e}")
+
+    # Report results
+    print("ASCII verification report")
+    print("=" * 25)
+    print(f"Scanned {total_files_scanned} text files in: {root_dir}")
+    print()
+
+    if not files_with_non_ascii:
+        print("SUCCESS: All text files contain only ASCII characters!")
+    else:
+        print(f"FOUND: {len(files_with_non_ascii)} file(s) with non-ASCII characters:")
+        print()
+
+        for filepath, non_ascii_lines in files_with_non_ascii:
+            print(f"File: {filepath}")
+            print(f"  Lines with non-ASCII characters: {len(non_ascii_lines)}")
+
+            # Show up to 5 example lines
+            for line_num, line, positions in non_ascii_lines[:5]:
+                print(
+                    f"  Line {line_num}: {highlight_non_ascii(line[:100], positions)}"
+                )
+                if len(line) > 100:
+                    print(f"           ... (truncated, {len(line)} chars total)")
+
+            if len(non_ascii_lines) > 5:
+                print(f"  ... and {len(non_ascii_lines) - 5} more line(s)")
+            print()
+
+        # Summary
+        print("Summary:")
+        print(f"  Files with non-ASCII: {len(files_with_non_ascii)}")
+        total_lines = sum(len(lines) for _, lines in files_with_non_ascii)
+        print(f"  Total lines affected: {total_lines}")
+
+
+def main():
+    # Use current directory if no argument provided
+    if len(sys.argv) > 1:
+        root_dir = sys.argv[1]
+    else:
+        root_dir = os.getcwd()
+
+    if not os.path.isdir(root_dir):
+        print(f"Error: {root_dir} is not a directory")
+        sys.exit(1)
+
+    scan_directory(root_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rtflite/services/text_conversion_service.py
+++ b/src/rtflite/services/text_conversion_service.py
@@ -45,10 +45,10 @@ class TextConversionService:
         Examples:
             >>> service = TextConversionService()
             >>> service.convert_text_content("\\alpha test", True)
-            "α test"
+            "\\u03b1 test"
 
             >>> service.convert_text_content(["\\alpha", "\\beta"], True)
-            ["α", "β"]
+            ["\\u03b1", "\\u03b2"]
         """
         if not enable_conversion or text is None:
             return text

--- a/tests/test_text_conversion_service.py
+++ b/tests/test_text_conversion_service.py
@@ -20,11 +20,11 @@ class TestTextConversionService:
         """Test conversion with string input."""
         # Basic LaTeX conversion
         result = self.service.convert_text_content("\\alpha test", True)
-        assert result == "α test"
+        assert result == "\u03b1 test"
         
         # Multiple symbols
         result = self.service.convert_text_content("\\alpha + \\beta = \\gamma", True)
-        assert result == "α + β = γ"
+        assert result == "\u03b1 + \u03b2 = \u03b3"
         
         # No LaTeX symbols
         result = self.service.convert_text_content("plain text", True)
@@ -36,7 +36,7 @@ class TestTextConversionService:
         result = self.service.convert_text_content(
             ["\\alpha", "\\beta", "plain"], True
         )
-        assert result == ["α", "β", "plain"]
+        assert result == ["\u03b1", "\u03b2", "plain"]
         
         # Empty list
         result = self.service.convert_text_content([], True)
@@ -46,7 +46,7 @@ class TestTextConversionService:
         result = self.service.convert_text_content(
             ["\\alpha test", "no latex", "\\beta end"], True
         )
-        assert result == ["α test", "no latex", "β end"]
+        assert result == ["\u03b1 test", "no latex", "\u03b2 end"]
 
     def test_convert_text_content_disabled(self):
         """Test that conversion is skipped when disabled."""
@@ -84,7 +84,7 @@ class TestTextConversionService:
         """Test _convert_single_text method directly."""
         # Normal conversion
         result = self.service._convert_single_text("\\alpha")
-        assert result == "α"
+        assert result == "\u03b1"
         
         # Empty string
         result = self.service._convert_single_text("")
@@ -116,15 +116,15 @@ class TestTextConversionService:
         """Test _convert_text_list method directly."""
         # Normal list
         result = self.service._convert_text_list(["\\alpha", "\\beta", "text"])
-        assert result == ["α", "β", "text"]
+        assert result == ["\u03b1", "\u03b2", "text"]
         
         # List with None values
         result = self.service._convert_text_list(["\\alpha", None, "\\beta"])
-        assert result == ["α", None, "β"]
+        assert result == ["\u03b1", None, "\u03b2"]
         
         # Empty strings in list
         result = self.service._convert_text_list(["", "\\alpha", ""])
-        assert result == ["", "α", ""]
+        assert result == ["", "\u03b1", ""]
 
     def test_convert_text_list_nested(self):
         """Test _convert_text_list with nested lists."""
@@ -135,19 +135,19 @@ class TestTextConversionService:
             "\\beta",
             "plain"
         ])
-        assert result == ["α", "β", "plain"]
+        assert result == ["\u03b1", "\u03b2", "plain"]
         
         # For non-string items, they're passed through unchanged
         # unless they're None
         result = self.service._convert_text_list(["\\alpha", None, "\\beta"])
-        assert result == ["α", None, "β"]
+        assert result == ["\u03b1", None, "\u03b2"]
 
     def test_convert_with_validation(self):
         """Test convert_with_validation method."""
         # Valid LaTeX commands
         result = self.service.convert_with_validation("\\alpha \\beta", True)
         assert "converted_text" in result
-        assert result["converted_text"] == "α β"
+        assert result["converted_text"] == "\u03b1 \u03b2"
         assert "validation" in result
         
         # Invalid LaTeX commands
@@ -199,27 +199,27 @@ class TestTextConversionService:
             "\\int_{\\alpha}^{\\beta} f(x) dx = \\sum_{i=1}^{n} x_i",
             True
         )
-        assert "∫" in result
-        assert "α" in result
-        assert "β" in result
-        assert "∑" in result
+        assert "\u222b" in result
+        assert "\u03b1" in result
+        assert "\u03b2" in result
+        assert "\u2211" in result
         
         # Mixed text and symbols
         result = self.service.convert_text_content(
             "The Greek letter \\alpha (alpha) and \\Omega (omega)",
             True
         )
-        assert result == "The Greek letter α (alpha) and Ω (omega)"
+        assert result == "The Greek letter \u03b1 (alpha) and \u03a9 (omega)"
 
     def test_special_characters_preservation(self):
         """Test that non-LaTeX special characters are preserved."""
         # Unicode characters should be preserved
-        result = self.service.convert_text_content("© ® ™ €", True)
-        assert result == "© ® ™ €"
+        result = self.service.convert_text_content("\u00a9 \u00ae \u2122 \u20ac", True)
+        assert result == "\u00a9 \u00ae \u2122 \u20ac"
         
         # Mixed with LaTeX
-        result = self.service.convert_text_content("\\alpha © \\beta ®", True)
-        assert result == "α © β ®"
+        result = self.service.convert_text_content("\\alpha \u00a9 \\beta \u00ae", True)
+        assert result == "\u03b1 \u00a9 \u03b2 \u00ae"
 
     def test_empty_and_whitespace_handling(self):
         """Test handling of empty strings and whitespace."""
@@ -231,7 +231,7 @@ class TestTextConversionService:
         
         # LaTeX with extra whitespace
         result = self.service.convert_text_content("  \\alpha  \\beta  ", True)
-        assert result == "  α  β  "
+        assert result == "  \u03b1  \u03b2  "  # Unicode escapes are interpreted here
 
     def test_conversion_statistics(self):
         """Test getting conversion statistics."""


### PR DESCRIPTION
This PR adds a reusable Python script that scans the package directory and identify all non-ASCII characters from text files.

Also scanned the directory and replaced all non-ASCII characters in impacted files with ASCII alternatives. Now it shows:

```bash
➜ python scripts/verify_ascii.py
ASCII verification report
=========================
Scanned 142 text files in: /Users/nanx/rtflite

SUCCESS: All text files contain only ASCII characters!
(rtflite)
```