### PR TITLE
Use admonitions for better visual and readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,12 +62,13 @@ pytest tests/specific_test.py
 pytest --cov=rtflite --cov-report=html:docs/coverage/
 ```
 
-If your terminal did not activate the virtual environment for some reason
-(with symptoms like not finding pytest commands), activate it manually:
+!!! tip "Virtual environment activation"
+    If your terminal did not activate the virtual environment for some reason
+    (with symptoms like not finding pytest commands), activate it manually:
 
-```bash
-source .venv/bin/activate
-```
+    ```bash
+    source .venv/bin/activate
+    ```
 
 ### Documentation
 

--- a/docs/articles/advanced-group-by.md
+++ b/docs/articles/advanced-group-by.md
@@ -18,11 +18,10 @@ Instead of repeating identical values in every row, `group_by` displays
 the value only once per group, leaving subsequent rows blank for better
 visual organization.
 
-Key benefits:
-
-- **Improved readability**: Reduces visual clutter by eliminating redundant information
-- **Clinical standards compliance**: Follows pharmaceutical industry conventions for listing formats
-- **Hierarchical grouping**: Supports multiple columns with nested group relationships
+!!! info "Key benefits"
+    - **Improved readability**: Reduces visual clutter by eliminating redundant information
+    - **Clinical standards compliance**: Follows pharmaceutical industry conventions for listing formats
+    - **Hierarchical grouping**: Supports multiple columns with nested group relationships
 
 ## Imports
 

--- a/docs/articles/converter-setup.md
+++ b/docs/articles/converter-setup.md
@@ -23,8 +23,9 @@ On Windows (using Chocolatey):
 choco install libreoffice
 ```
 
-After installation, restart your shell to ensure `PATH` updates are loaded
-so that rtflite can find LibreOffice.
+!!! tip
+    After installation, restart your shell to ensure `PATH` updates are loaded
+    so that rtflite can find LibreOffice.
 
 ## Using the converter
 
@@ -122,15 +123,17 @@ RUN apt-get update && apt-get install -y libreoffice
 
 ### Version requirements
 
-rtflite requires LibreOffice version 7.1 or higher. Check your version:
+!!! warning "Minimum version requirement"
+    rtflite requires LibreOffice version 7.1 or higher. Check your version:
 
-```bash
-soffice --version
-```
+    ```bash
+    soffice --version
+    ```
 
 ## Performance tips
 
-1. LibreOffice starts a background process for conversions.
-2. For batch conversions, reuse the same converter instance.
-3. The first conversion may be slower as LibreOffice initializes.
-4. Consider using thread-based parallel processing for large batches.
+!!! tip "Optimization suggestions"
+    1. LibreOffice starts a background process for conversions.
+    2. For batch conversions, reuse the same converter instance.
+    3. The first conversion may be slower as LibreOffice initializes.
+    4. Consider using thread-based parallel processing for large batches.

--- a/docs/articles/format-page.md
+++ b/docs/articles/format-page.md
@@ -19,11 +19,10 @@ to control this behavior:
 
 ## Default behavior
 
-By default:
-
-- Titles appear on **all pages** (`page_title="all"`)
-- Footnotes appear on the **last page only** (`page_footnote="last"`)
-- Sources appear on the **last page only** (`page_source="last"`)
+!!! info "Default settings"
+    - Titles appear on **all pages** (`page_title="all"`)
+    - Footnotes appear on the **last page only** (`page_footnote="last"`)
+    - Sources appear on the **last page only** (`page_source="last"`)
 
 ## Examples
 

--- a/docs/articles/format-row.md
+++ b/docs/articles/format-row.md
@@ -27,8 +27,9 @@ import rtflite as rtf
 
 ## Border styles
 
-> Please refer to the `rtf` output. The converted PDF version has known issues
-> for some border types due to converter (LibreOffice) limitations.
+!!! warning "PDF conversion limitation"
+    Please refer to the `.rtf` output. The converted PDF version has known issues
+    for some border types due to converter (LibreOffice) limitations.
 
 Demonstrate different border types:
 

--- a/docs/articles/format-text.md
+++ b/docs/articles/format-text.md
@@ -55,7 +55,8 @@ print(df_formats)
 
 Apply text formatting using column-based approach:
 
-> Using tuples `()` allows user to define parameters by row.
+!!! tip
+    Using tuples `()` allows user to define parameters by row.
 
 ```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 # Apply text formatting by row

--- a/docs/articles/pagination.md
+++ b/docs/articles/pagination.md
@@ -24,18 +24,19 @@ The pagination feature automatically splits large tables across multiple RTF pag
 
 ### Border management
 
-The pagination system implements a three-tier border hierarchy matching r2rtf design:
+!!! info "Three-tier border hierarchy"
+    The pagination system implements a three-tier border hierarchy matching r2rtf design:
 
-1. **`rtf_page.border_first/border_last`**: Controls borders for the entire table
-   - `border_first`: Applied to first row of first page (default: "double")
-   - `border_last`: Applied to last row of last page (default: "double")
+    1. **`rtf_page.border_first/border_last`**: Controls borders for the entire table
+       - `border_first`: Applied to first row of first page (default: "double")
+       - `border_last`: Applied to last row of last page (default: "double")
 
-2. **`rtf_body.border_first/border_last`**: Controls borders for each page
-   - `border_first`: Applied to first row of each non-first page (default: "single")
-   - `border_last`: Applied to last row of each non-last page (default: "single")
+    2. **`rtf_body.border_first/border_last`**: Controls borders for each page
+       - `border_first`: Applied to first row of each non-first page (default: "single")
+       - `border_last`: Applied to last row of each non-last page (default: "single")
 
-3. **`rtf_body.border_top/bottom/left/right`**: Controls borders for individual cells
-   - Standard cell borders maintained throughout the table
+    3. **`rtf_body.border_top/bottom/left/right`**: Controls borders for individual cells
+       - Standard cell borders maintained throughout the table
 
 ### Column header repetition
 

--- a/docs/articles/quickstart.md
+++ b/docs/articles/quickstart.md
@@ -59,7 +59,8 @@ df.select(["USUBJID", "TRTA", "AEDECOD"]).head(4)
 The polars package is used for data manipulation to create a data frame
 that contains all the information we want to add in an RTF table.
 
-> Please note other packages can also be used for the same purpose.
+!!! note
+    Other dataframe packages can also be used for the same purpose.
 
 In this AE example, we provide number of subjects with each type of AE by treatment group.
 
@@ -349,13 +350,12 @@ converter.convert("text-convert.rtf", output_dir="../pdf/", format="pdf", overwr
 
 <embed src="../pdf/text-convert.pdf" style="width:100%; height:400px" type="application/pdf">
 
-### Key points about text conversion
-
-- **Default behavior**: `text_convert = True` for all components (titles, data, footnotes, and sources)
-- **Underscore patterns**: `a_b` becomes subscript when conversion is enabled
-- **LaTeX symbols**: `\\alpha`, `\\beta`, etc. convert to Unicode symbols
-- **Control per component**: Each RTF component can have independent conversion settings
-- **Performance**: Disabling conversion can improve performance for large tables with no LaTeX content
+!!! info "Key points about text conversion"
+    - **Default behavior**: `text_convert = True` for all components (titles, data, footnotes, and sources)
+    - **Underscore patterns**: `a_b` becomes subscript when conversion is enabled
+    - **LaTeX symbols**: `\\alpha`, `\\beta`, etc. convert to Unicode symbols
+    - **Control per component**: Each RTF component can have independent conversion settings
+    - **Performance**: Disabling conversion can improve performance for large tables with no LaTeX content
 
 ## Border customization
 
@@ -555,14 +555,13 @@ converter.convert("intro-ae11.rtf", output_dir="../pdf/", format="pdf", overwrit
 
 <embed src="../pdf/intro-ae11.pdf" style="width:100%; height:400px" type="application/pdf">
 
-### Multi-page considerations
+!!! info "Multi-page considerations"
+    For large tables spanning multiple pages, rtflite handles:
 
-For large tables spanning multiple pages, rtflite handles:
-
-- Automatic page breaks based on `nrow` setting
-- Column header repetition on each page
-- Consistent border styling across page boundaries
-- Proper footnote and source placement
+    - Automatic page breaks based on `nrow` setting
+    - Column header repetition on each page
+    - Consistent border styling across page boundaries
+    - Proper footnote and source placement
 
 ```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 # Large table with consistent formatting across pages

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -62,12 +62,13 @@ pytest tests/specific_test.py
 pytest --cov=rtflite --cov-report=html:docs/coverage/
 ```
 
-If your terminal did not activate the virtual environment for some reason
-(with symptoms like not finding pytest commands), activate it manually:
+!!! tip "Virtual environment activation"
+    If your terminal did not activate the virtual environment for some reason
+    (with symptoms like not finding pytest commands), activate it manually:
 
-```bash
-source .venv/bin/activate
-```
+    ```bash
+    source .venv/bin/activate
+    ```
 
 ### Documentation
 


### PR DESCRIPTION
This PR improves the documentation by converting plain Markdown blockquotes and key sections to proper mkdocs-material admonitions for better visual hierarchy and readability.

Changes:

- Converted blockquotes (`) to appropriate admonition types (note, warning, tip).
- Added info admonitions for key points and important details sections.
- Improved visual structure of technical documentation with proper callouts.

Affected files:

- `docs/articles/quickstart.md` - Package notes, key points about text conversion, multi-page considerations
- `docs/articles/format-row.md` - PDF conversion limitation warning
- `docs/articles/format-text.md` - Tip about tuple usage
- `docs/articles/pagination.md` - Three-tier border hierarchy info box
- `docs/articles/converter-setup.md` - Shell restart tip, version requirements, performance tips
- `docs/articles/advanced-group-by.md` - Key benefits section
- `docs/articles/format-page.md` - Default settings info
- `CONTRIBUTING.md` and `docs/contributing.md` - Virtual environment activation tip

The admonitions now provide better visual cues for different types of information - warnings for limitations, tips for helpful suggestions, info boxes for key concepts, and notes for general information.