### PR TITLE
Improve the flow and technical accuracy of articles

### DIFF
--- a/docs/articles/converter-setup.md
+++ b/docs/articles/converter-setup.md
@@ -1,7 +1,7 @@
 # Converter setup
 
 rtflite can convert RTF documents to PDF using LibreOffice.
-This guide helps you set up LibreOffice for PDF conversion functionality.
+This guide shows how to install and use LibreOffice for PDF conversion.
 
 ## Install LibreOffice
 
@@ -29,7 +29,7 @@ choco install libreoffice
 
 ## Using the converter
 
-Once LibreOffice is installed, you can convert RTF files to PDF in your code:
+Once LibreOffice is installed, convert RTF files to PDF in your code:
 
 ```python
 import rtflite as rtf

--- a/docs/articles/example-baseline.md
+++ b/docs/articles/example-baseline.md
@@ -26,7 +26,7 @@ df = pl.read_parquet(data_path)
 print(df)
 ```
 
-Create header data frames:
+Create header rows:
 
 ```python exec="on" source="above" session="default"
 header1 = ["", "Placebo", "Drug Low Dose", "Drug High Dose", "Total"]

--- a/docs/articles/example-efficacy.md
+++ b/docs/articles/example-efficacy.md
@@ -8,8 +8,8 @@ converter = LibreOfficeConverter()
 
 This example demonstrates how to create a multi-section efficacy table
 using rtflite's multi-section functionality.
-The table shows ANCOVA analysis results with multiple sections:
-summary statistics, treatment comparison, and model diagnostics.
+The table shows ANCOVA results with separate sections for summary statistics,
+treatment comparisons, and model diagnostics.
 
 ## Imports
 
@@ -41,7 +41,7 @@ tbl3 = pl.read_parquet(data_path3)
 
 ## Define multi-section RTF table
 
-Create RTF document with multiple sections using the new multi-section API:
+Create an RTF document with multiple sections:
 
 ```python exec="on" source="above" session="default"
 # Define headers for each section

--- a/docs/articles/format-row.md
+++ b/docs/articles/format-row.md
@@ -6,9 +6,8 @@ from rtflite import LibreOfficeConverter
 converter = LibreOfficeConverter()
 ```
 
-This article demonstrates row-level formatting capabilities in rtflite.
-It covers borders, cell alignment, column widths, and text formatting
-for creating professional tables.
+This article demonstrates row-level formatting in rtflite: borders,
+cell alignment, column widths, and text formatting to create professional tables.
 
 ## Overview
 
@@ -28,8 +27,8 @@ import rtflite as rtf
 ## Border styles
 
 !!! warning "PDF conversion limitation"
-    Please refer to the `.rtf` output. The converted PDF version has known issues
-    for some border types due to converter (LibreOffice) limitations.
+    Prefer reviewing the `.rtf` output. Some border styles may not render
+    perfectly in PDF due to LibreOffice conversion quirks.
 
 Demonstrate different border types:
 
@@ -63,7 +62,7 @@ converter.convert("row-border-styles.rtf", output_dir="../pdf/", format="pdf", o
 
 ## Column widths
 
-Control relative column widths:
+Control relative column widths using `col_rel_width`:
 
 ```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 # Create width demonstration data

--- a/docs/articles/format-text.md
+++ b/docs/articles/format-text.md
@@ -6,9 +6,9 @@ from rtflite import LibreOfficeConverter
 converter = LibreOfficeConverter()
 ```
 
-This article demonstrates advanced text formatting capabilities in rtflite.
-It covers fonts, colors, alignment, indentation, special characters,
-and comprehensive formatting for clinical documentation.
+This article demonstrates advanced text formatting capabilities in rtflite:
+fonts, colors, alignment, indentation, special characters, and
+common patterns for clinical documentation.
 
 ## Overview
 
@@ -53,10 +53,10 @@ df_formats = pl.DataFrame(
 print(df_formats)
 ```
 
-Apply text formatting using column-based approach:
+Apply text formatting using a column-based approach:
 
 !!! tip
-    Using tuples `()` allows user to define parameters by row.
+    Use tuples `()` to specify per-row attributes.
 
 ```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 # Apply text formatting by row
@@ -151,7 +151,7 @@ converter.convert("text-color.rtf", output_dir="../pdf/", format="pdf", overwrit
 
 ## Indentation
 
-Show indentation options for hierarchical content:
+Show indentation options for hierarchical content (values are in twips):
 
 ```python exec="on" source="above" session="default" result="text"
 # Create indentation demonstration data

--- a/docs/articles/pagination.md
+++ b/docs/articles/pagination.md
@@ -97,7 +97,7 @@ Each paginated document follows this structure:
 {\pard\fs2\par}\page{\pard\fs2\par}  # Page break
 \paperw...\paperh...      # Page setup (repeated)
 \margl...\margr...        # Margins (repeated)
-[Title content]           # Optional (based on page_title_location)
+[Title content]           # Optional (based on page_title setting)
 [Column headers]          # Repeated with appropriate borders
 [Table rows nrow+1-2*nrow] # Continued data content
 ...
@@ -191,9 +191,9 @@ RTFDocument
 - `nrow`: Rows per page (auto-calculated if not specified)
 - `border_first`: Border style for entire table start
 - `border_last`: Border style for entire table end
-- `page_title_location`: "all", "first", or "last"
-- `page_footnote_location`: "all", "first", or "last"
-- `page_source_location`: "all", "first", or "last"
+- `page_title`: "all", "first", or "last"
+- `page_footnote`: "all", "first", or "last"
+- `page_source`: "all", "first", or "last"
 
 ### RTFBody settings
 

--- a/docs/articles/quickstart.md
+++ b/docs/articles/quickstart.md
@@ -8,11 +8,11 @@ converter = LibreOfficeConverter()
 
 ## Overview
 
-rtflite is a Python package to create production-ready tables and figures in RTF format.
-The package is designed to:
+rtflite is a Python package for creating production-ready tables and figures
+in RTF format. The package is designed to:
 
-- Provide simple component classes that correspond to each element of a table,
-  such as title, headers, body, footnotes, for intuitive table construction.
+- Provide simple Python classes that map to table elements
+  (title, headers, body, footnotes) for intuitive table construction.
 - Offer a canonical Python API with a clear, composable interface.
 - Focus exclusively on **table formatting and layout**,
   leaving data manipulation to dataframe libraries like polars or pandas.
@@ -24,9 +24,8 @@ Creating an RTF table involves three steps:
 - Configure the appropriate rtflite components.
 - Generate and save the RTF document.
 
-This document introduces rtflite's core components and demonstrates how to
-transform dataframes into Tables, Listings, and Figures (TLFs) for
-clinical reporting.
+This guide introduces rtflite's core components and demonstrates how to turn
+dataframes into Tables, Listings, and Figures (TLFs) for clinical reporting.
 
 ## Data: adverse events
 
@@ -58,8 +57,8 @@ df.select(["USUBJID", "TRTA", "AEDECOD"]).head(4)
 
 ## Table-ready data
 
-The polars package is used for data manipulation to create a dataframe
-that contains all the information we want to add in an RTF table.
+We use polars for data manipulation to create a dataframe with the information
+we want to render in an RTF table.
 
 !!! note
     Other dataframe packages can also be used for the same purpose.
@@ -152,8 +151,8 @@ converter.convert("intro-ae2.rtf", output_dir="../pdf/", format="pdf", overwrite
 
 ## Column headers
 
-In `RTFColumnHeader`, `text` argument is used to provide content of column header.
-We used a list to separate the columns.
+In `RTFColumnHeader`, the `text` argument provides the column header content
+as a list of strings.
 
 ```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 # Create RTF document with column headers
@@ -181,7 +180,7 @@ converter.convert("intro-ae3.rtf", output_dir="../pdf/", format="pdf", overwrite
 
 We also allow column headers be displayed in multiple lines.
 If an empty column name is needed for a column,
-you can insert an empty string; e.g., `["name 1", "", "name 3"]`.
+you can insert an empty string. For example, `["name 1", "", "name 3"]`.
 
 In `RTFColumnHeader`, the `col_rel_width` can be used to align column header
 with different number of columns.
@@ -353,11 +352,14 @@ converter.convert("text-convert.rtf", output_dir="../pdf/", format="pdf", overwr
 <embed src="../pdf/text-convert.pdf" style="width:100%; height:400px" type="application/pdf">
 
 !!! info "Key points about text conversion"
-    - **Default behavior**: `text_convert = True` for all components (titles, data, footnotes, and sources)
-    - **Underscore patterns**: `a_b` becomes subscript when conversion is enabled
-    - **LaTeX symbols**: `\\alpha`, `\\beta`, etc. convert to Unicode symbols
-    - **Control per component**: Each RTF component can have independent conversion settings
-    - **Performance**: Disabling conversion can improve performance for large tables with no LaTeX content
+    - **Default behavior**: `text_convert = True` for all components
+      (titles, data, footnotes, sources).
+    - **Underscore patterns**: `a_b` becomes subscript when conversion is enabled.
+    - **LaTeX symbols**: `\\alpha`, `\\beta`, etc. convert to Unicode symbols.
+    - **Control per component**: Each RTF component can have independent
+      conversion settings.
+    - **Performance**: Disabling conversion can improve performance for large
+      tables with no LaTeX content.
 
 ## Border customization
 

--- a/src/rtflite/convert.py
+++ b/src/rtflite/convert.py
@@ -13,49 +13,13 @@ from .dictionary.libreoffice import DEFAULT_PATHS, MIN_VERSION
 class LibreOfficeConverter:
     """Convert RTF documents to other formats using LibreOffice.
 
-    The LibreOfficeConverter enables conversion of RTF files to various formats
-    including PDF, DOCX, HTML, and others using LibreOffice in headless mode.
-    It automatically detects LibreOffice installation on Windows, macOS, and Linux.
-
-    Examples:
-        Basic PDF conversion:
-        ```python
-        from rtflite import LibreOfficeConverter
-
-        converter = LibreOfficeConverter()
-        converter.convert("report.rtf", format="pdf")
-        # Creates report.pdf in the same directory
-        ```
-
-        Convert multiple files to specific directory:
-        ```python
-        converter = LibreOfficeConverter()
-        converter.convert(
-            input_files=["report1.rtf", "report2.rtf"],
-            output_dir="pdf_output/",
-            format="pdf",
-            overwrite=True
-        )
-        ```
-
-        Convert to Word format:
-        ```python
-        converter.convert("report.rtf", format="docx")
-        # Creates report.docx
-        ```
-
-    Supported Formats:
-        - pdf: Portable Document Format
-        - docx: Microsoft Word (Office Open XML)
-        - doc: Microsoft Word 97-2003
-        - html: HTML Document
-        - odt: OpenDocument Text
-        - txt: Plain Text
+    Convert RTF files to various formats including PDF, DOCX, HTML, and others
+    using LibreOffice in headless mode.
 
     Requirements:
-        - LibreOffice 7.3 or later must be installed
-        - Automatically finds LibreOffice in standard installation paths
-        - For custom installations, provide executable_path parameter
+        - LibreOffice 7.3 or later must be installed.
+        - Automatically finds LibreOffice in standard installation paths.
+        - For custom installations, provide `executable_path` parameter.
 
     Note:
         The converter runs LibreOffice in headless mode, so no GUI is required.


### PR DESCRIPTION
This PR is a follow-up of #86 to further improve the writing flow and accuracy of more articles under `docs/articles/`.

Also removes the problematic docstring examples from the `LibreOfficeConverter` class.