### PR TITLE
Fix hard-coded font in pagination calculations

### DIFF
--- a/src/rtflite/pagination/core.py
+++ b/src/rtflite/pagination/core.py
@@ -86,10 +86,19 @@ class PageBreakCalculator(BaseModel):
                             value=table_attrs.text_font_size, dimension=dim
                         ).iloc(row_idx, col_idx)
 
+                    # Get actual font from table attributes if available
+                    actual_font = 1  # Default to font number 1 (Times New Roman)
+                    if table_attrs and hasattr(table_attrs, "text_font"):
+                        from ..attributes import BroadcastValue
+
+                        actual_font = BroadcastValue(
+                            value=table_attrs.text_font, dimension=dim
+                        ).iloc(row_idx, col_idx)
+
                     # Calculate how many lines this text will need
-                    # Use default font (Times New Roman) with actual font size
+                    # Use the actual font from table attributes with actual font size
                     text_width = get_string_width(
-                        cell_value, "Times New Roman", actual_font_size
+                        cell_value, font=actual_font, font_size=actual_font_size
                     )
                     lines_needed = max(1, int(text_width / col_width) + 1)
                     max_lines_in_row = max(max_lines_in_row, lines_needed)

--- a/tests/test_pagination_font.py
+++ b/tests/test_pagination_font.py
@@ -1,0 +1,167 @@
+"""Test that font information is properly passed through pagination system."""
+
+import polars as pl
+
+from rtflite.input import RTFBody
+from rtflite.pagination import PageBreakCalculator, RTFPagination
+
+
+class TestPaginationFont:
+    """Test font handling in pagination calculations."""
+
+    def test_font_passed_to_string_width_calculation(self):
+        """Test that font from RTFBody is used in content row calculations."""
+        # Create test data with text that will wrap differently based on font
+        df = pl.DataFrame(
+            {
+                "col1": [
+                    "Short",
+                    "This is a much, much, much, much, much, much, much, much, much, much longer piece of text that wraps differently with fonts",
+                ],
+                "col2": ["Val1", "Another value that demonstrates font differences"],
+            }
+        )
+
+        # Create pagination configuration
+        pagination = RTFPagination(
+            page_width=8.5,
+            page_height=11,
+            margin=[1, 1, 1, 1, 0.5, 0.5],
+            nrow=10,
+            orientation="portrait",
+        )
+
+        calculator = PageBreakCalculator(pagination=pagination)
+
+        # Test with Times New Roman (proportional font)
+        body_times = RTFBody(
+            text_font=[[1, 1]],  # Font 1: Times New Roman
+            text_font_size=[[12, 12]],
+            col_rel_width=[1, 1],
+        )
+
+        # Test with Courier New (monospace font)
+        body_courier = RTFBody(
+            text_font=[[9, 9]],  # Font 9: Courier New
+            text_font_size=[[12, 12]],
+            col_rel_width=[1, 1],
+        )
+
+        # Use narrow columns to force text wrapping
+        col_widths = [1.5, 1.5]
+
+        rows_times = calculator.calculate_content_rows(
+            df, col_widths, body_times, font_size=12
+        )
+
+        rows_courier = calculator.calculate_content_rows(
+            df, col_widths, body_courier, font_size=12
+        )
+
+        # Different fonts should produce different row calculations for long text
+        assert rows_times != rows_courier, (
+            "Different fonts should produce different row counts"
+        )
+
+        # Monospace font should generally need more rows for the same text
+        assert rows_courier[1] >= rows_times[1], (
+            "Courier New should need at least as many rows as Times New Roman"
+        )
+
+    def test_font_broadcast_in_mixed_table(self):
+        """Test that different fonts in different cells are handled correctly."""
+        df = pl.DataFrame(
+            {
+                "col1": ["Text in Times", "Text in Courier"],
+                "col2": ["Text in Arial", "Text in Georgia"],
+            }
+        )
+
+        pagination = RTFPagination(
+            page_width=8.5,
+            page_height=11,
+            margin=[1, 1, 1, 1, 0.5, 0.5],
+            nrow=10,
+            orientation="portrait",
+        )
+
+        calculator = PageBreakCalculator(pagination=pagination)
+
+        # Different font for each cell
+        body_mixed = RTFBody(
+            text_font=[[1, 4], [9, 7]],  # Times, Arial; Courier, Georgia
+            text_font_size=[[12, 12], [12, 12]],
+            col_rel_width=[1, 1],
+        )
+
+        col_widths = [2.0, 2.0]
+
+        # Should complete without errors and use correct fonts for each cell
+        rows = calculator.calculate_content_rows(
+            df, col_widths, body_mixed, font_size=12
+        )
+
+        assert len(rows) == 2, "Should calculate rows for each data row"
+        assert all(r >= 1 for r in rows), "Each row should need at least 1 line"
+
+    def test_default_font_when_no_table_attrs(self):
+        """Test that default font (1) is used when no table attributes provided."""
+        df = pl.DataFrame({"col1": ["Text"], "col2": ["Value"]})
+
+        pagination = RTFPagination(
+            page_width=8.5,
+            page_height=11,
+            margin=[1, 1, 1, 1, 0.5, 0.5],
+            nrow=10,
+            orientation="portrait",
+        )
+
+        calculator = PageBreakCalculator(pagination=pagination)
+        col_widths = [2.0, 2.0]
+
+        # Call without table_attrs - should use default font 1
+        rows = calculator.calculate_content_rows(df, col_widths, None, font_size=12)
+
+        assert len(rows) == 1, "Should calculate rows"
+        assert rows[0] >= 1, "Should need at least 1 line"
+
+    def test_font_size_and_font_both_respected(self):
+        """Test that both font and font size from table attrs are used."""
+        df = pl.DataFrame(
+            {"col1": ["Same text repeated"], "col2": ["Same text repeated"]}
+        )
+
+        pagination = RTFPagination(
+            page_width=8.5,
+            page_height=11,
+            margin=[1, 1, 1, 1, 0.5, 0.5],
+            nrow=10,
+            orientation="portrait",
+        )
+
+        calculator = PageBreakCalculator(pagination=pagination)
+
+        # Small font size with Times
+        body_small = RTFBody(
+            text_font=[[1, 1]], text_font_size=[[8, 8]], col_rel_width=[1, 1]
+        )
+
+        # Large font size with Times
+        body_large = RTFBody(
+            text_font=[[1, 1]], text_font_size=[[16, 16]], col_rel_width=[1, 1]
+        )
+
+        col_widths = [1.0, 1.0]  # Narrow columns
+
+        rows_small = calculator.calculate_content_rows(
+            df, col_widths, body_small, font_size=12
+        )
+
+        rows_large = calculator.calculate_content_rows(
+            df, col_widths, body_large, font_size=12
+        )
+
+        # Larger font size should need more rows
+        assert rows_large[0] > rows_small[0], (
+            "Larger font size should need more rows for same text"
+        )


### PR DESCRIPTION
Fixes #88

This PR fixes the hard-coded font issue in `src/rtflite/pagination/core.py`. The `calculate_content_rows` method was using a hard-coded "Times New Roman" (font number: 1) font instead of reading the font from the table attributes that were already being passed in.

The fix makes sure that user-selected fonts are properly passed through the entire call stack from `RTFDocument` -> `RTFBody` -> `PageBreakCalculator.calculate_content_rows` -> `get_string_width`, thus allowing accurate text width calculations for pagination.

## Core change

1. `src/rtflite/pagination/core.py`: Added code to extract the actual font from `table_attrs.text_font` using the same `BroadcastValue` pattern used for font size.
2. `src/rtflite/pagination/core.py`: Updated the `get_string_width` call to use the actual font instead of hard-coded `"Times New Roman"`.

## More tests...

Created unit tests in `tests/test_font_pagination.py` to verify:

- Different fonts produce different row calculations.
- Font broadcast works correctly for mixed font tables.
- Default font number (`1`) is used when no table attributes provided.
- Both font and font size are respected together.