### PR TITLE
Add missing RTF snapshots

### DIFF
--- a/tests/fixtures/mkdocs_outputs/intro-ae10.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae10.rtf
@@ -1,0 +1,275 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw15840\paperh12240\landscape 
+\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Adverse Events Summary - Landscape Layout}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdash\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdash\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdash\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdash\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACTINIC KERATOSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AGITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALCOHOL USE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALLERGIC GRANULOMATOUS ANGIITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALOPECIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AMNESIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw15840\paperh12240
+
+\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
+
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Adverse Events Summary - Landscape Layout}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ANXIETY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE BLEEDING}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DERMATITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DESQUAMATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DISCHARGE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DISCOLOURATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE ERYTHEMA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 23}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 20}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE INDURATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE IRRITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 16}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 18}\cell
+\intbl\row\pard
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw15840\paperh12240
+
+\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
+
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Adverse Events Summary - Landscape Layout}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdash\brdrw15\clvertalt\cellx4896
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdash\brdrw15\clvertalt\cellx7344
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdash\brdrw15\clvertalt\cellx9792
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdash\brdrw15\clvertalt\cellx12240
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE PERSPIRATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/intro-ae11.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae11.rtf
@@ -1,0 +1,68 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/intro-ae12.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae12.rtf
@@ -1,0 +1,618 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Complete Adverse Events Summary}\line\fs24{\f0 All Treatment Groups - Multi-page Table}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Placebo\line (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline High Dose\line (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline Low Dose\line (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ACTINIC KERATOSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 AGITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ALCOHOL USE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ALLERGIC GRANULOMATOUS ANGIITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ALOPECIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 AMNESIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ANXIETY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE BLEEDING}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE DERMATITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15}\cell
+\intbl\row\pard
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw12240\paperh15840
+
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Complete Adverse Events Summary}\line\fs24{\f0 All Treatment Groups - Multi-page Table}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Placebo\line (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline High Dose\line (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline Low Dose\line (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE DESQUAMATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE DISCHARGE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE DISCOLOURATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE ERYTHEMA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 23}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 20}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE INDURATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE IRRITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 16}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 18}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE PERSPIRATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE PRURITUS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 10}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 35}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 33}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE REACTION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE SWELLING}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE URTICARIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw12240\paperh15840
+
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Complete Adverse Events Summary}\line\fs24{\f0 All Treatment Groups - Multi-page Table}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Placebo\line (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline High Dose\line (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline Low Dose\line (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE VESICLES}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE WARMTH}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ARTHRALGIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ARTHRITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ASTHENIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ATRIAL FIBRILLATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ATRIAL FLUTTER}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ATRIAL HYPERTROPHY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ATRIOVENTRICULAR BLOCK FIRST DEGREE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ATRIOVENTRICULAR BLOCK SECOND DEGREE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BACK PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BALANCE DISORDER}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw12240\paperh15840
+
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Complete Adverse Events Summary}\line\fs24{\f0 All Treatment Groups - Multi-page Table}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Placebo\line (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline High Dose\line (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline Low Dose\line (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BENIGN PROSTATIC HYPERPLASIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BIOPSY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BIOPSY PROSTATE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BLISTER}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BLOOD ALKALINE PHOSPHATASE INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BLOOD CHOLESTEROL INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BLOOD CREATINE PHOSPHOKINASE INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BLOOD GLUCOSE INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BLOOD URINE PRESENT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BODY TEMPERATURE INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BRADYCARDIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BRONCHITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw12240\paperh15840
+
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Complete Adverse Events Summary}\line\fs24{\f0 All Treatment Groups - Multi-page Table}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Placebo\line (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline High Dose\line (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline Low Dose\line (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BUNDLE BRANCH BLOCK LEFT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 BUNDLE BRANCH BLOCK RIGHT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 MedDRA version 25.0 coding applied.\line Table includes all reported adverse events regardless of relationship to study drug.\line Events sorted alphabetically by preferred term.}\cell
+\intbl\row\pard
+{\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Dataset: ADAE | Cutoff: 01JAN2023}\par}
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/intro-ae3.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae3.rtf
@@ -1,0 +1,98 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACTINIC KERATOSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AGITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALCOHOL USE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/intro-ae4.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae4.rtf
@@ -1,0 +1,606 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Treatment}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACTINIC KERATOSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AGITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALCOHOL USE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALLERGIC GRANULOMATOUS ANGIITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALOPECIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AMNESIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ANXIETY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE BLEEDING}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DERMATITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DESQUAMATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw12240\paperh15840
+
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Treatment}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DISCHARGE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DISCOLOURATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE ERYTHEMA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 23}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 20}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE INDURATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE IRRITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 16}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 18}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE PERSPIRATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE PRURITUS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 10}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 35}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 33}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE REACTION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE SWELLING}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE URTICARIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE VESICLES}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE WARMTH}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw12240\paperh15840
+
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Treatment}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ARTHRALGIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ARTHRITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ASTHENIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ATRIAL FIBRILLATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ATRIAL FLUTTER}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ATRIAL HYPERTROPHY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ATRIOVENTRICULAR BLOCK FIRST DEGREE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ATRIOVENTRICULAR BLOCK SECOND DEGREE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BACK PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BALANCE DISORDER}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BENIGN PROSTATIC HYPERPLASIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BIOPSY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BIOPSY PROSTATE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw12240\paperh15840
+
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Treatment}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BLISTER}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BLOOD ALKALINE PHOSPHATASE INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BLOOD CHOLESTEROL INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BLOOD CREATINE PHOSPHOKINASE INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BLOOD GLUCOSE INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BLOOD URINE PRESENT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BODY TEMPERATURE INCREASED}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BRADYCARDIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BRONCHITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BUNDLE BRANCH BLOCK LEFT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 BUNDLE BRANCH BLOCK RIGHT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/intro-ae5.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae5.rtf
@@ -1,0 +1,193 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Summary of Adverse Events by Treatment Group}\line\fs24{\f0 Safety Analysis Set}\par}
+
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo\line (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose\line (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose\line (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACTINIC KERATOSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AGITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALCOHOL USE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALLERGIC GRANULOMATOUS ANGIITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALOPECIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AMNESIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ANXIETY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE BLEEDING}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DERMATITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DESQUAMATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DISCHARGE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DISCOLOURATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Adverse events are coded using MedDRA version 25.0.\line Events are sorted alphabetically by preferred term.}\cell
+\intbl\row\pard
+{\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Source: ADAE dataset, Data cutoff: 01JAN2023}\par}
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/intro-ae6.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae6.rtf
@@ -1,0 +1,138 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Xanomeline Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ACTINIC KERATOSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 AGITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ALCOHOL USE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ALLERGIC GRANULOMATOUS ANGIITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ALOPECIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 AMNESIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx6000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx7500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ANXIETY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\intbl\row\pard
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/intro-ae7.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae7.rtf
@@ -1,0 +1,118 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalb\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACTINIC KERATOSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AGITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALCOHOL USE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALLERGIC GRANULOMATOUS ANGIITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALOPECIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/intro-ae8.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae8.rtf
@@ -1,0 +1,188 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+{\header{\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qr\fs24{\f0 Page \chpgn of {\field{\*\fldinst NUMPAGES }}}\par}}
+{\footer{\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs24{\f0 Confidential - Clinical Study Report}\par}}
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Summary of Adverse Events by Treatment Group}\line\fs24{\f0 With Page Headers and Footers}\par}
+
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo (N=86)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose (N=84)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose (N=84)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACTINIC KERATOSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AGITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALCOHOL USE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALLERGIC GRANULOMATOUS ANGIITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALOPECIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AMNESIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ANXIETY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE BLEEDING}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DERMATITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DESQUAMATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DISCHARGE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 APPLICATION SITE DISCOLOURATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\intbl\row\pard
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/intro-ae8b.rtf
+++ b/tests/fixtures/mkdocs_outputs/intro-ae8b.rtf
@@ -1,0 +1,138 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+{\header{\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs20{\f0\b Study XYZ-123 | Page \chpgn}\par}}
+{\footer{\pard\hyphpar\sb15\sa15\fi0\li0\ri0\ql\fs16{\f0 Company Confidential}\par}}
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Adverse Events with Custom Headers/Footers}\par}
+
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Adverse Events}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Xanomeline Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL DISCOMFORT}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ABDOMINAL PAIN}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACROCHORDON EXCISION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ACTINIC KERATOSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AGITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALCOHOL USE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALLERGIC GRANULOMATOUS ANGIITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ALOPECIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 AMNESIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx3000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ANXIETY}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\intbl\row\pard
+
+
+
+}

--- a/tests/fixtures/mkdocs_outputs/text-convert.rtf
+++ b/tests/fixtures/mkdocs_outputs/text-convert.rtf
@@ -1,0 +1,72 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Study Parameters with Text Conversion Enabled}\par}
+
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6750
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Parameter}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Value}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Unit}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6750
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 x\sub max}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15.2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 mg/L}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6750
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 y\sub min}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8.7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 cm}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6750
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 z\sub avg}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12.1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 C}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6750
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 a\sub b\sub ratio}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.85}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 ratio}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Note: Underscores x_max and y_min in footnote as is}\cell
+\intbl\row\pard
+
+
+
+}


### PR DESCRIPTION
This PR runs `sh scripts/check_rtf.sh` and adds the RTF snapshots (intro-ae3 to 12, and text-convert) that were missing from the currently saved RTF snapshots under `tests/fixtures/mkdocs_outputs/`.