### PR TITLE
Refactor type annotations to use abstract base classes

### DIFF
--- a/src/rtflite/core/constants.py
+++ b/src/rtflite/core/constants.py
@@ -4,7 +4,8 @@ This module eliminates magic numbers scattered throughout the codebase and provi
 clear documentation for all RTF-related constants used in the library.
 """
 
-from typing import Dict, Final
+from collections.abc import Mapping
+from typing import Final
 
 
 class RTFConstants:
@@ -63,7 +64,7 @@ class RTFConstants:
         ROW_END: Final[str] = "\\row"
 
     # === Format Codes ===
-    FORMAT_CODES: Final[Dict[str, str]] = {
+    FORMAT_CODES: Final[Mapping[str, str]] = {
         "": "",
         "b": "\\b",  # Bold
         "i": "\\i",  # Italic
@@ -74,7 +75,7 @@ class RTFConstants:
     }
 
     # === Text Justification Codes ===
-    TEXT_JUSTIFICATION_CODES: Final[Dict[str, str]] = {
+    TEXT_JUSTIFICATION_CODES: Final[Mapping[str, str]] = {
         "": "",
         "l": "\\ql",  # Left
         "c": "\\qc",  # Center
@@ -84,7 +85,7 @@ class RTFConstants:
     }
 
     # === Row Justification Codes ===
-    ROW_JUSTIFICATION_CODES: Final[Dict[str, str]] = {
+    ROW_JUSTIFICATION_CODES: Final[Mapping[str, str]] = {
         "": "",
         "l": "\\trql",  # Left
         "c": "\\trqc",  # Center
@@ -92,7 +93,7 @@ class RTFConstants:
     }
 
     # === Border Style Codes ===
-    BORDER_CODES: Final[Dict[str, str]] = {
+    BORDER_CODES: Final[Mapping[str, str]] = {
         "single": "\\brdrs",
         "double": "\\brdrdb",
         "thick": "\\brdrth",
@@ -112,7 +113,7 @@ class RTFConstants:
     }
 
     # === Vertical Alignment Codes ===
-    VERTICAL_ALIGNMENT_CODES: Final[Dict[str, str]] = {
+    VERTICAL_ALIGNMENT_CODES: Final[Mapping[str, str]] = {
         "top": "\\clvertalt",
         "center": "\\clvertalc",
         "bottom": "\\clvertalb",
@@ -122,7 +123,7 @@ class RTFConstants:
     }
 
     # === Character Conversion Mapping ===
-    RTF_CHAR_MAPPING: Final[Dict[str, str]] = {
+    RTF_CHAR_MAPPING: Final[Mapping[str, str]] = {
         "^": "\\super ",
         "_": "\\sub ",
         ">=": "\\geq ",
@@ -154,7 +155,7 @@ class RTFDefaults:
 
     # === Color Defaults ===
     @classmethod
-    def get_default_colors(cls) -> Dict[str, str]:
+    def get_default_colors(cls) -> Mapping[str, str]:
         """Get all colors from the comprehensive color table."""
         from rtflite.dictionary.color_table import name_to_rtf
 
@@ -164,7 +165,7 @@ class RTFDefaults:
     _default_colors_cache = None
 
     @classmethod
-    def DEFAULT_COLORS(cls) -> Dict[str, str]:
+    def DEFAULT_COLORS(cls) -> Mapping[str, str]:
         """Get all colors from the comprehensive color table (cached)."""
         if cls._default_colors_cache is None:
             cls._default_colors_cache = cls.get_default_colors()

--- a/src/rtflite/encode.py
+++ b/src/rtflite/encode.py
@@ -4,6 +4,8 @@ This module provides the RTFDocument class with a clean, service-oriented archit
 All complex logic has been delegated to specialized services and strategies.
 """
 
+from collections.abc import Sequence
+
 import polars as pl
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -138,13 +140,13 @@ class RTFDocument(BaseModel):
     rtf_subline: RTFSubline | None = Field(
         default=None, description="Subject line text to appear below the title"
     )
-    rtf_column_header: list[RTFColumnHeader] | list[list[RTFColumnHeader | None]] = (
-        Field(
-            default_factory=lambda: [RTFColumnHeader()],
-            description="Column header settings. For multi-section documents, use nested list format: [[header1], [header2], [None]] where None means no header for that section.",
-        )
+    rtf_column_header: (
+        Sequence[RTFColumnHeader] | Sequence[Sequence[RTFColumnHeader | None]]
+    ) = Field(
+        default_factory=lambda: [RTFColumnHeader()],
+        description="Column header settings. For multi-section documents, use nested list format: [[header1], [header2], [None]] where None means no header for that section.",
     )
-    rtf_body: RTFBody | list[RTFBody] | None = Field(
+    rtf_body: RTFBody | Sequence[RTFBody] | None = Field(
         default_factory=lambda: RTFBody(),
         description="Table body section settings including column widths and formatting. For multi-section documents, provide a list of RTFBody objects.",
     )

--- a/src/rtflite/encoding/strategies.py
+++ b/src/rtflite/encoding/strategies.py
@@ -87,7 +87,7 @@ class SinglePageStrategy(EncodingStrategy):
         )
         page_border_top = None
         page_border_bottom = None
-        if document.rtf_body is not None and not isinstance(document.rtf_body, list):
+        if document.rtf_body is not None and is_single_body(document.rtf_body):
             page_border_top_list = BroadcastValue(
                 value=document.rtf_body.border_first, dimension=(1, dim[1])
             ).to_list()

--- a/src/rtflite/figure.py
+++ b/src/rtflite/figure.py
@@ -5,12 +5,13 @@ for embedding in RTF documents.
 """
 
 import mimetypes
+from collections.abc import Sequence
 from pathlib import Path
 
 
 def rtf_read_figure(
-    file_paths: str | Path | list[str | Path],
-) -> tuple[list[bytes], list[str]]:
+    file_paths: str | Path | Sequence[str | Path],
+) -> tuple[Sequence[bytes], Sequence[str]]:
     """Read image files and return their binary data with format information.
 
     This function reads image files from disk and prepares them for embedding

--- a/src/rtflite/fonts_mapping.py
+++ b/src/rtflite/fonts_mapping.py
@@ -76,7 +76,7 @@ class FontMapping:
         }
 
     @staticmethod
-    def get_font_name_to_number_mapping() -> dict[FontName, int]:
+    def get_font_name_to_number_mapping() -> Mapping[FontName, int]:
         """Get mapping from font names to font numbers."""
         return {
             "Times New Roman": 1,
@@ -92,13 +92,13 @@ class FontMapping:
         }
 
     @staticmethod
-    def get_font_number_to_name_mapping() -> dict[int, FontName]:
+    def get_font_number_to_name_mapping() -> Mapping[int, FontName]:
         """Get mapping from font numbers to font names."""
         name_to_number = FontMapping.get_font_name_to_number_mapping()
         return {v: k for k, v in name_to_number.items()}
 
     @staticmethod
-    def get_font_paths() -> dict[FontName, str]:
+    def get_font_paths() -> Mapping[FontName, str]:
         """Get mapping from font names to font file paths."""
         return {
             "Times New Roman": "liberation/LiberationSerif-Regular.ttf",

--- a/src/rtflite/pagination/core.py
+++ b/src/rtflite/pagination/core.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import polars as pl
@@ -22,7 +22,7 @@ class RTFPagination(BaseModel):
     nrow: int = Field(..., description="Maximum rows per page")
     orientation: str = Field(..., description="Page orientation")
 
-    def calculate_available_space(self) -> dict[str, float]:
+    def calculate_available_space(self) -> Mapping[str, float]:
         """Calculate available space for content on each page"""
         content_width = (
             self.page_width - self.margin[0] - self.margin[1]
@@ -51,10 +51,10 @@ class PageBreakCalculator(BaseModel):
     def calculate_content_rows(
         self,
         df: pl.DataFrame,
-        col_widths: list[float],
+        col_widths: Sequence[float],
         table_attrs: TableAttributes | None = None,
         font_size: float = 9,
-    ) -> list[int]:
+    ) -> Sequence[int]:
         """Calculate how many rows each content row will occupy when rendered
 
         Args:
@@ -133,12 +133,12 @@ class PageBreakCalculator(BaseModel):
     def find_page_breaks(
         self,
         df: pl.DataFrame,
-        col_widths: list[float],
-        page_by: list[str] | None = None,
+        col_widths: Sequence[float],
+        page_by: Sequence[str] | None = None,
         new_page: bool = False,
         table_attrs: TableAttributes | None = None,
         additional_rows_per_page: int = 0,
-    ) -> list[tuple[int, int]]:
+    ) -> Sequence[tuple[int, int]]:
         """Find optimal page break positions (r2rtf compatible)
 
         Args:
@@ -206,14 +206,14 @@ class ContentDistributor(BaseModel):
     def distribute_content(
         self,
         df: pl.DataFrame,
-        col_widths: list[float],
-        page_by: list[str] | None = None,
+        col_widths: Sequence[float],
+        page_by: Sequence[str] | None = None,
         new_page: bool = False,
         pageby_header: bool = True,
         table_attrs: TableAttributes | None = None,
         additional_rows_per_page: int = 0,
-        subline_by: list[str] | None = None,
-    ) -> list[dict[str, Any]]:
+        subline_by: Sequence[str] | None = None,
+    ) -> Sequence[Mapping[str, Any]]:
         """Distribute content across multiple pages (r2rtf compatible)
 
         Args:
@@ -265,8 +265,8 @@ class ContentDistributor(BaseModel):
         return pages
 
     def get_group_headers(
-        self, df: pl.DataFrame, page_by: list[str], start_row: int
-    ) -> dict[str, Any]:
+        self, df: pl.DataFrame, page_by: Sequence[str], start_row: int
+    ) -> Mapping[str, Any]:
         """Get group header information for a page
 
         Args:

--- a/src/rtflite/rtf/syntax.py
+++ b/src/rtflite/rtf/syntax.py
@@ -1,5 +1,6 @@
 """RTF syntax generation utilities."""
 
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from ..core.constants import RTFConstants
@@ -44,7 +45,7 @@ class RTFSyntaxGenerator:
         return font_table
 
     @staticmethod
-    def generate_color_table(used_colors: list[str] | None = None) -> str:
+    def generate_color_table(used_colors: Sequence[str] | None = None) -> str:
         """Generate RTF color table using comprehensive 657-color support.
 
         Args:
@@ -59,7 +60,10 @@ class RTFSyntaxGenerator:
 
     @staticmethod
     def generate_page_settings(
-        width: float, height: float, margins: list[float], orientation: str = "portrait"
+        width: float,
+        height: float,
+        margins: Sequence[float],
+        orientation: str = "portrait",
     ) -> str:
         """Generate RTF page settings.
 
@@ -112,7 +116,7 @@ class RTFDocumentAssembler:
     def __init__(self):
         self.syntax = RTFSyntaxGenerator()
 
-    def assemble_document(self, components: dict[str, Any]) -> str:
+    def assemble_document(self, components: Mapping[str, Any]) -> str:
         """Assemble a complete RTF document from components.
 
         Args:

--- a/src/rtflite/services/advanced_pagination_service.py
+++ b/src/rtflite/services/advanced_pagination_service.py
@@ -125,10 +125,11 @@ class AdvancedPaginationService:
                 start_row=config.start_row + row_offset,
                 end_row=config.end_row + row_offset,
                 break_type=config.break_type,
-                section_headers=config.section_headers + [f"Section {section_idx + 1}"],
+                section_headers=list(config.section_headers)
+                + [f"Section {section_idx + 1}"],
                 subline_header=config.subline_header,
-                group_context=config.group_context.copy(),
-                forced_content=config.forced_content.copy(),
+                group_context=dict(config.group_context),
+                forced_content=set(config.forced_content),
             )
 
             main_page_dict.add_page_config(new_config)
@@ -192,7 +193,7 @@ class AdvancedPaginationService:
         if self.page_dict is None:
             return []
 
-        return self.page_dict.to_legacy_page_info()
+        return [dict(page_info) for page_info in self.page_dict.to_legacy_page_info()]
 
     def optimize_pagination(self) -> None:
         """Optimize pagination for better balance and readability"""

--- a/src/rtflite/services/color_service.py
+++ b/src/rtflite/services/color_service.py
@@ -4,6 +4,7 @@ This service provides comprehensive color validation, lookup, and RTF generation
 capabilities using the full 657-color table from r2rtf.
 """
 
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from rtflite.dictionary.color_table import (
@@ -103,7 +104,7 @@ class ColorService:
 
     def get_color_suggestions(
         self, partial_color: str, max_suggestions: int = 5
-    ) -> list[str]:
+    ) -> Sequence[str]:
         """Get color name suggestions for partial matches.
 
         Args:
@@ -138,9 +139,7 @@ class ColorService:
 
         return suggestions
 
-    def validate_color_list(
-        self, colors: str | list[str] | tuple[str, ...]
-    ) -> list[str]:
+    def validate_color_list(self, colors: str | Sequence[str]) -> Sequence[str]:
         """Validate a list of colors, converting single color to list.
 
         Args:
@@ -183,7 +182,7 @@ class ColorService:
 
         return validated_colors
 
-    def needs_color_table(self, used_colors: list[str] | None = None) -> bool:
+    def needs_color_table(self, used_colors: Sequence[str] | None = None) -> bool:
         """Check if a color table is needed based on used colors.
 
         Args:
@@ -201,7 +200,7 @@ class ColorService:
         ]
         return len(significant_colors) > 0
 
-    def generate_rtf_color_table(self, used_colors: list[str] | None = None) -> str:
+    def generate_rtf_color_table(self, used_colors: Sequence[str] | None = None) -> str:
         """Generate RTF color table definition for used colors.
 
         Args:
@@ -256,7 +255,7 @@ class ColorService:
             return "".join(rtf_parts)
 
     def get_rtf_color_index(
-        self, color: str, used_colors: list[str] | None = None
+        self, color: str, used_colors: Sequence[str] | None = None
     ) -> int:
         """Get the RTF color table index for a color in the context of a specific document.
 
@@ -292,7 +291,7 @@ class ColorService:
         except ValueError:
             return 0
 
-    def get_all_color_names(self) -> list[str]:
+    def get_all_color_names(self) -> Sequence[str]:
         """Get list of all available color names.
 
         Returns:
@@ -308,7 +307,7 @@ class ColorService:
         """
         return len(self._name_to_type)
 
-    def collect_document_colors(self, document) -> list[str]:
+    def collect_document_colors(self, document) -> Sequence[str]:
         """Collect all colors used in a document.
 
         Args:
@@ -391,7 +390,9 @@ class ColorService:
 
         return list(used_colors)
 
-    def set_document_context(self, document=None, used_colors: list[str] | None = None):
+    def set_document_context(
+        self, document=None, used_colors: Sequence[str] | None = None
+    ):
         """Set the document context for color index resolution.
 
         Args:
@@ -406,7 +407,7 @@ class ColorService:
         """Clear the document context."""
         self._current_document_colors = None
 
-    def get_color_info(self, color: str) -> dict[str, Any]:
+    def get_color_info(self, color: str) -> Mapping[str, Any]:
         """Get comprehensive information about a color.
 
         Args:
@@ -444,6 +445,8 @@ def get_color_index(color: str) -> int:
     return color_service.get_color_index(color)
 
 
-def get_color_suggestions(partial_color: str, max_suggestions: int = 5) -> list[str]:
+def get_color_suggestions(
+    partial_color: str, max_suggestions: int = 5
+) -> Sequence[str]:
     """Get color name suggestions for partial matches."""
     return color_service.get_color_suggestions(partial_color, max_suggestions)

--- a/src/rtflite/services/document_service.py
+++ b/src/rtflite/services/document_service.py
@@ -1,6 +1,7 @@
 """RTF Document Service - handles all document-level operations."""
 
-from typing import List, Tuple
+from collections.abc import Mapping, Sequence
+from typing import Any, Tuple
 
 
 class RTFDocumentService:
@@ -97,7 +98,7 @@ class RTFDocumentService:
                 document.rtf_body[0].col_rel_width, col_total_width
             )
             # Calculate rows needed for all sections combined
-            total_content_rows = []
+            total_content_rows: list[Any] = []
             for df, body in zip(document.df, document.rtf_body):
                 section_col_widths = Utils._col_widths(
                     body.col_rel_width, col_total_width
@@ -112,8 +113,10 @@ class RTFDocumentService:
                 document.rtf_body.col_rel_width, col_total_width
             )
             # Calculate rows needed for data content only
-            content_rows = calculator.calculate_content_rows(
-                document.df, col_widths, document.rtf_body
+            content_rows = list(
+                calculator.calculate_content_rows(
+                    document.df, col_widths, document.rtf_body
+                )
             )
 
         # Calculate additional rows per page
@@ -169,7 +172,9 @@ class RTFDocumentService:
         else:
             return False
 
-    def process_page_by(self, document) -> List[List[Tuple[int, int, int]]] | None:
+    def process_page_by(
+        self, document
+    ) -> Sequence[Sequence[Tuple[int, int, int]]] | None:
         """Create components for page_by format."""
         # Obtain input data
         data = document.df.to_dicts()
@@ -189,7 +194,7 @@ class RTFDocumentService:
             """Get the index of a column in the column list."""
             return columns.index(column_name)
 
-        def get_matching_rows(group_values: dict) -> List[int]:
+        def get_matching_rows(group_values: Mapping) -> Sequence[int]:
             """Get row indices that match the group values."""
             return [
                 i
@@ -197,7 +202,7 @@ class RTFDocumentService:
                 if all(row[k] == v for k, v in group_values.items())
             ]
 
-        def get_unique_combinations(variables: List[str]) -> List[dict]:
+        def get_unique_combinations(variables: Sequence[str]) -> Sequence[Mapping]:
             """Get unique combinations of values for the specified variables."""
             seen = set()
             unique = []

--- a/src/rtflite/services/encoding_service.py
+++ b/src/rtflite/services/encoding_service.py
@@ -1,5 +1,7 @@
 """RTF encoding service that handles document component encoding."""
 
+from collections.abc import Sequence
+
 from .grouping_service import grouping_service
 
 
@@ -24,7 +26,7 @@ class RTFEncodingService:
         return self.syntax.generate_font_table()
 
     def encode_color_table(
-        self, document=None, used_colors: list[str] | None = None
+        self, document=None, used_colors: Sequence[str] | None = None
     ) -> str:
         """Encode RTF color table with comprehensive 657-color support.
 
@@ -131,7 +133,7 @@ class RTFEncodingService:
         footnote_config,
         page_number: int | None = None,
         page_col_width: float | None = None,
-    ) -> list[str]:
+    ) -> Sequence[str]:
         """Encode footnote component with advanced formatting.
 
         Args:
@@ -193,7 +195,7 @@ class RTFEncodingService:
         source_config,
         page_number: int | None = None,
         page_col_width: float | None = None,
-    ) -> list[str]:
+    ) -> Sequence[str]:
         """Encode source component with advanced formatting.
 
         Args:
@@ -279,7 +281,7 @@ class RTFEncodingService:
 
     def encode_body(
         self, document, df, rtf_attrs, force_single_page=False
-    ) -> list[str] | None:
+    ) -> Sequence[str] | None:
         """Encode table body component with full pagination support.
 
         Args:
@@ -386,7 +388,9 @@ class RTFEncodingService:
 
         return rows
 
-    def _encode_body_paginated(self, document, df, rtf_attrs, col_widths) -> list[str]:
+    def _encode_body_paginated(
+        self, document, df, rtf_attrs, col_widths
+    ) -> Sequence[str]:
         """Encode body content with pagination support."""
         from .document_service import RTFDocumentService
 
@@ -444,7 +448,7 @@ class RTFEncodingService:
 
     def encode_column_header(
         self, df, rtf_attrs, page_col_width: float
-    ) -> list[str] | None:
+    ) -> Sequence[str] | None:
         """Encode column header component with column width support.
 
         Args:

--- a/src/rtflite/services/figure_service.py
+++ b/src/rtflite/services/figure_service.py
@@ -3,6 +3,8 @@
 This module provides services for encoding images into RTF format.
 """
 
+from collections.abc import Sequence
+
 from ..figure import rtf_read_figure
 from ..input import RTFFigure
 
@@ -51,9 +53,9 @@ class RTFFigureService:
         return "".join(rtf_output)
 
     @staticmethod
-    def _get_dimension(dimension: float | list[float], index: int) -> float:
+    def _get_dimension(dimension: float | Sequence[float], index: int) -> float:
         """Get dimension for specific figure index."""
-        if isinstance(dimension, list):
+        if not isinstance(dimension, (int, float)):
             return dimension[index] if index < len(dimension) else dimension[-1]
         return dimension
 

--- a/src/rtflite/services/grouping_service.py
+++ b/src/rtflite/services/grouping_service.py
@@ -6,7 +6,8 @@ group_by columns are displayed only once per group, with subsequent rows
 showing blank/suppressed values for better readability.
 """
 
-from typing import Any, Dict
+from collections.abc import Mapping, MutableSequence, Sequence
+from typing import Any
 
 import polars as pl
 
@@ -18,7 +19,7 @@ class GroupingService:
         pass
 
     def enhance_group_by(
-        self, df: pl.DataFrame, group_by: list[str] | None = None
+        self, df: pl.DataFrame, group_by: Sequence[str] | None = None
     ) -> pl.DataFrame:
         """Apply group_by value suppression to a DataFrame
 
@@ -82,7 +83,7 @@ class GroupingService:
         return result_df
 
     def _suppress_hierarchical_columns(
-        self, df: pl.DataFrame, group_by: list[str]
+        self, df: pl.DataFrame, group_by: Sequence[str]
     ) -> pl.DataFrame:
         """Suppress duplicate values in hierarchical group columns
 
@@ -135,8 +136,8 @@ class GroupingService:
         self,
         suppressed_df: pl.DataFrame,
         original_df: pl.DataFrame,
-        group_by: list[str],
-        page_start_indices: list[int],
+        group_by: Sequence[str],
+        page_start_indices: Sequence[int],
     ) -> pl.DataFrame:
         """Restore group context at the beginning of new pages
 
@@ -181,8 +182,8 @@ class GroupingService:
         return result_df
 
     def get_group_structure(
-        self, df: pl.DataFrame, group_by: list[str]
-    ) -> Dict[str, Any]:
+        self, df: pl.DataFrame, group_by: Sequence[str]
+    ) -> Mapping[str, Any]:
         """Analyze the group structure of a DataFrame
 
         Args:
@@ -216,8 +217,8 @@ class GroupingService:
         }
 
     def validate_group_by_columns(
-        self, df: pl.DataFrame, group_by: list[str]
-    ) -> list[str]:
+        self, df: pl.DataFrame, group_by: Sequence[str]
+    ) -> Sequence[str]:
         """Validate group_by columns and return any issues
 
         Args:
@@ -227,7 +228,7 @@ class GroupingService:
         Returns:
             List of validation issues (empty if all valid)
         """
-        issues: list[str] = []
+        issues: MutableSequence[str] = []
 
         if not group_by:
             return issues
@@ -253,9 +254,9 @@ class GroupingService:
     def validate_data_sorting(
         self,
         df: pl.DataFrame,
-        group_by: list[str] | None = None,
-        page_by: list[str] | None = None,
-        subline_by: list[str] | None = None,
+        group_by: Sequence[str] | None = None,
+        page_by: Sequence[str] | None = None,
+        subline_by: Sequence[str] | None = None,
     ) -> None:
         """Validate that data is properly sorted for grouping operations
 
@@ -275,7 +276,7 @@ class GroupingService:
             return
 
         # Collect all grouping variables
-        all_grouping_vars = []
+        all_grouping_vars: list[str] = []
 
         # Add variables in priority order (page_by, subline_by, group_by)
         if page_by:
@@ -374,8 +375,8 @@ class GroupingService:
                         seen_keys.add(current_key)
 
     def validate_subline_formatting_consistency(
-        self, df: pl.DataFrame, subline_by: list[str], rtf_body
-    ) -> list[str]:
+        self, df: pl.DataFrame, subline_by: Sequence[str], rtf_body
+    ) -> Sequence[str]:
         """Validate that formatting is consistent within each column after broadcasting
 
         When using subline_by, we need to ensure that after broadcasting formatting
@@ -391,7 +392,7 @@ class GroupingService:
         Returns:
             List of warning messages
         """
-        warnings: list[str] = []
+        warnings: MutableSequence[str] = []
 
         if not subline_by or df.is_empty():
             return warnings
@@ -468,9 +469,9 @@ class GroupingService:
 
     def _validate_no_overlapping_grouping_vars(
         self,
-        group_by: list[str] | None = None,
-        page_by: list[str] | None = None,
-        subline_by: list[str] | None = None,
+        group_by: Sequence[str] | None = None,
+        page_by: Sequence[str] | None = None,
+        subline_by: Sequence[str] | None = None,
     ) -> None:
         """Validate that grouping variables don't overlap between different types
 

--- a/src/rtflite/services/text_conversion_service.py
+++ b/src/rtflite/services/text_conversion_service.py
@@ -6,6 +6,8 @@ within the RTF document generation process. It integrates the text
 conversion functionality with the broader service architecture.
 """
 
+from collections.abc import Mapping, Sequence
+
 from ..text_conversion import LaTeXSymbolMapper, TextConverter
 
 
@@ -25,8 +27,8 @@ class TextConversionService:
         self.symbol_mapper = LaTeXSymbolMapper()
 
     def convert_text_content(
-        self, text: str | list[str] | None, enable_conversion: bool = True
-    ) -> str | list[str] | None:
+        self, text: str | Sequence[str] | None, enable_conversion: bool = True
+    ) -> str | Sequence[str] | None:
         """
         Convert text content with LaTeX commands to Unicode.
 
@@ -80,7 +82,7 @@ class TextConversionService:
             print(f"Warning: Text conversion failed for '{text}': {e}")
             return text
 
-    def _convert_text_list(self, text_list: list[str]) -> list[str]:
+    def _convert_text_list(self, text_list: Sequence[str]) -> list[str]:
         """
         Convert a list of text strings.
 
@@ -92,7 +94,7 @@ class TextConversionService:
         """
         return [self._convert_single_text(item) for item in text_list]
 
-    def get_supported_symbols(self) -> list[str]:
+    def get_supported_symbols(self) -> Sequence[str]:
         """
         Get a list of all supported LaTeX symbols.
 
@@ -101,7 +103,7 @@ class TextConversionService:
         """
         return self.symbol_mapper.get_all_supported_commands()
 
-    def get_symbol_categories(self) -> dict:
+    def get_symbol_categories(self) -> Mapping[str, Sequence[str]]:
         """
         Get LaTeX symbols organized by category.
 
@@ -110,7 +112,7 @@ class TextConversionService:
         """
         return self.symbol_mapper.get_commands_by_category()
 
-    def validate_latex_commands(self, text: str) -> dict:
+    def validate_latex_commands(self, text: str) -> Mapping[str, object]:
         """
         Validate LaTeX commands in text and provide feedback.
 
@@ -153,7 +155,7 @@ class TextConversionService:
 
     def convert_with_validation(
         self, text: str, enable_conversion: bool = True
-    ) -> dict:
+    ) -> Mapping[str, object]:
         """
         Convert text and return both result and validation information.
 

--- a/src/rtflite/strwidth.py
+++ b/src/rtflite/strwidth.py
@@ -1,5 +1,6 @@
 import importlib.resources as pkg_resources
 import math
+from collections.abc import Mapping
 from typing import Literal
 
 from PIL import ImageFont
@@ -14,7 +15,7 @@ Unit = Literal["in", "mm", "px"]
 _FONT_PATHS = FontMapping.get_font_paths()
 
 RTF_FONT_NUMBERS = FontMapping.get_font_name_to_number_mapping()
-RTF_FONT_NAMES: dict[int, FontName] = FontMapping.get_font_number_to_name_mapping()
+RTF_FONT_NAMES: Mapping[int, FontName] = FontMapping.get_font_number_to_name_mapping()
 
 # Check Pillow version to determine if size parameter should be int or float
 _PILLOW_VERSION = tuple(map(int, PILLOW_VERSION.split(".")[:2]))

--- a/src/rtflite/text_conversion/symbols.py
+++ b/src/rtflite/text_conversion/symbols.py
@@ -6,7 +6,7 @@ characters. It organizes the symbols into logical categories for better
 maintainability and readability.
 """
 
-from typing import Dict
+from collections.abc import Mapping, Sequence
 
 from ..dictionary.unicode_latex import latex_to_char, latex_to_unicode, unicode_to_int
 
@@ -61,7 +61,7 @@ class LaTeXSymbolMapper:
         # Optimized: use the single-lookup dictionary for consistency
         return latex_command in self.latex_to_char
 
-    def get_all_supported_commands(self) -> list[str]:
+    def get_all_supported_commands(self) -> Sequence[str]:
         """
         Get a list of all supported LaTeX commands.
 
@@ -71,7 +71,7 @@ class LaTeXSymbolMapper:
         # Optimized: use the single-lookup dictionary
         return list(self.latex_to_char.keys())
 
-    def get_commands_by_category(self) -> Dict[str, list[str]]:
+    def get_commands_by_category(self) -> Mapping[str, Sequence[str]]:
         """
         Organize LaTeX commands by category for better understanding.
 

--- a/src/rtflite/type_guards.py
+++ b/src/rtflite/type_guards.py
@@ -1,32 +1,35 @@
 """Type guards for RTF components to handle Union types safely."""
 
+from collections.abc import Sequence
 from typing import Any, TypeGuard
 
 from .input import RTFBody, RTFColumnHeader
 
 
 def is_single_header(
-    header: RTFColumnHeader | list[RTFColumnHeader | None] | None,
+    header: RTFColumnHeader | Sequence[RTFColumnHeader | None] | None,
 ) -> TypeGuard[RTFColumnHeader]:
     """Check if header is a single RTFColumnHeader instance."""
-    return header is not None and not isinstance(header, list)
+    return header is not None and not isinstance(header, (list, tuple))
 
 
-def is_single_body(body: RTFBody | list[RTFBody] | None) -> TypeGuard[RTFBody]:
+def is_single_body(body: RTFBody | Sequence[RTFBody] | None) -> TypeGuard[RTFBody]:
     """Check if body is a single RTFBody instance."""
-    return body is not None and not isinstance(body, list)
+    return body is not None and not isinstance(body, (list, tuple))
 
 
 def is_list_header(
-    header: RTFColumnHeader | list[RTFColumnHeader | None] | None,
-) -> TypeGuard[list[RTFColumnHeader | None]]:
-    """Check if header is a list of RTFColumnHeader instances."""
-    return isinstance(header, list)
+    header: RTFColumnHeader | Sequence[RTFColumnHeader | None] | None,
+) -> TypeGuard[Sequence[RTFColumnHeader | None]]:
+    """Check if header is a sequence of RTFColumnHeader instances."""
+    return isinstance(header, (list, tuple))
 
 
-def is_list_body(body: RTFBody | list[RTFBody] | None) -> TypeGuard[list[RTFBody]]:
-    """Check if body is a list of RTFBody instances."""
-    return isinstance(body, list)
+def is_list_body(
+    body: RTFBody | Sequence[RTFBody] | None,
+) -> TypeGuard[Sequence[RTFBody]]:
+    """Check if body is a sequence of RTFBody instances."""
+    return isinstance(body, (list, tuple))
 
 
 def is_nested_header_list(


### PR DESCRIPTION
This PR replaces concrete type annotations (`list`, `dict`, `tuple`, `set`) with abstract base classes from collections.abc (`Sequence`, `Mapping`, `MutableSequence`, `MutableMapping`, `Set`, `MutableSet`) in function parameters and interfaces.

This change promotes polymorphism, improves code reusability, and follows modern Python typing best practices by accepting any implementation that provides the required interface rather than specific concrete types.

@elong0527 you might want to review some of the changes below, especially the logic updates in encoding strategies and advanced pagination service.

## Changes made

**Type guard** (`src/rtflite/type_guards.py`):

- Updated type guard functions to use `Sequence[RTFBody]` instead of `list[RTFBody]`
- Modified `is_single_body` and `is_list_body` to check for sequences using `isinstance(body, (list, tuple))`
- Enhanced `is_single_header` and `is_list_header` for consistency with sequence types

**Encoding strategies** (`src/rtflite/encoding/strategies.py`):

- Critical Logic Change: Replaced `isinstance(document.rtf_body, list)` with `is_single_body(document.rtf_body)` type guard on line 90. This is a **significant change** that affects the core encoding logic for determining whether to treat RTF body as a single component or a sequence. The type guard provides proper type narrowing for mypy while maintaining the same runtime behavior but with support for any sequence type, not just lists.

**Advanced pagination service** (`src/rtflite/services/advanced_pagination_service.py`):

Logic changes in `_merge_section_pages` method (lines 128-132):

- Line 128: Changed `config.section_headers + [f"Section {section_idx + 1}"]` to `list(config.section_headers) + [...]` because `MutableSequence` doesn't support the `+` operator
- Line 131: Changed `config.group_context.copy()` to `dict(config.group_context)` because `MutableMapping` doesn't have a `copy()` method
- Line 132: Changed `config.forced_content.copy()` to `set(config.forced_content)` because `MutableSet` doesn't have a `copy()` method

Logic change in `convert_to_legacy_format` method (line 196):

- Added explicit conversion `[dict(page_info) for page_info in self.page_dict.to_legacy_page_info()]` to convert `Sequence[Mapping[str, Any]]` to the required `list[dict[str, Any]]` return type

**Pagination data structures** (`src/rtflite/pagination/page_dict.py`):

Important logic changes:

- Lines 96-99: Changed `MutableSequence[PageBreakRule]` to `list[PageBreakRule]` for the break_rules field because the code calls `.sort()` method which is not available in the `MutableSequence` protocol
- Line 99: Changed `MutableMapping[str, MutableSequence[int]]` to `MutableMapping[str, list[int]]` for the same reason
- Line 125: Updated return type from `Sequence[int]` to `list[int]` to match the concrete type being returned

These changes in pagination are critical because they involve data structures that need specific operations (sorting) not available in abstract base classes, requiring concrete types.

## Service layer updates

- All service classes: Updated method parameters to use `Sequence[T]` instead of `list[T]`, `Mapping[K,V]` instead of `dict[K,V]`
- Text conversion service: Parameters now accept any sequence type
- Color service: Method signatures use abstract types for better polymorphism
- Document service: Fixed type annotation for `total_content_rows` variable and return type conversions

## Minor type fixes

- Added missing `Any` import in `document_service.py`
- Fixed return type in `figure_service.py` by improving type narrowing logic
- Added explicit type annotations for local variables where mypy required them

## Testing

- All mypy type checks pass
- All pytest tests pass
- `check_rtf.sh` pass