### PR TITLE
Refine text component defaults and pagination planning

### DIFF
--- a/src/rtflite/attributes.py
+++ b/src/rtflite/attributes.py
@@ -1,6 +1,6 @@
 import math
 from collections.abc import Callable, Iterable, MutableSequence, Sequence
-from typing import Any, Tuple, TypeVar
+from typing import Any, Tuple, TypeVar, cast
 
 import narwhals as nw
 import polars as pl
@@ -33,7 +33,7 @@ def _iter_nested(value: Sequence[T]) -> Iterable[T]:
     first = value[0]
     if isinstance(first, Sequence) and not isinstance(first, (str, bytes)):
         for row in value:
-            yield from row  # type: ignore[arg-type]
+            yield from cast(Sequence[T], row)
     else:
         yield from value
 


### PR DESCRIPTION
## Summary
- replace the mixin/defaults factory pattern with shared helpers that apply class-level defaults and tuple coercion for text components
- tighten table text handling with declarative defaults, strict boolean validation for `as_table`, and subclass overrides for headers, footers, titles, and sources
- centralize pagination analysis in a new `PaginationPlanner` used by `RTFDocumentService` to compute additional rows, content rows, and distributors

## Testing
- UV_PYTHON=3.12 uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d09a020f4c8331a702bca2371e66eb