### PR TITLE
Link assemble article in `mkdocs.yml`

### DIFF
--- a/docs/articles/assemble.md
+++ b/docs/articles/assemble.md
@@ -1,6 +1,6 @@
 # Assemble
 
-This example demonstrates how to assemble multiple RTF files into a single RTF or DOCX file using `rtflite`.
+This article demonstrates how to assemble multiple RTF files into a single RTF or DOCX file using rtflite.
 
 ```python exec="on" session="default"
 from rtflite import LibreOfficeConverter
@@ -15,17 +15,16 @@ from rtflite import assemble_rtf, assemble_docx
 
 # Define input files
 
-```python exec="on" source="above" session="default"
-docs_dir = Path("./rtf")
+```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 input_files = [
-    str(docs_dir / "example-ae-summary.rtf"),
-    str(docs_dir / "example-efficacy.rtf"),
+    "example-ae-summary.rtf",
+    "example-efficacy.rtf",
 ]
 ```
 
 # Assemble into RTF
 
-```python exec="on" session="default" workdir="docs/articles/rtf/"
+```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 assemble_rtf(input_files, "combined.rtf")
 ```
 
@@ -37,13 +36,13 @@ converter.convert("combined.rtf", output_dir="../pdf/", format="pdf", overwrite=
 
 # Assemble into DOCX
 
-```python exec="on" session="default" workdir="docs/articles/rtf/"
+```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 assemble_docx(input_files, "combined.docx")
 ```
 
 # Assemble into DOCX with mixed orientation (Portrait, Landscape)
 
-```python exec="on" session="default" workdir="docs/articles/rtf/"
+```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 assemble_docx(
     input_files,
     "combined_mixed.docx",

--- a/docs/articles/rtf/combined.rtf
+++ b/docs/articles/rtf/combined.rtf
@@ -1,0 +1,465 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset1\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset0\fprq2 Arial;}
+{\f4\fswiss\fcharset1\fprq2 Helvetica;}
+{\f5\fswiss\fcharset1\fprq2 Calibri;}
+{\f6\froman\fcharset1\fprq2 Georgia;}
+{\f7\ffroman\fcharset1\fprq2 Cambria;}
+{\f8\fmodern\fcharset0\fprq2 Courier New;}
+{\f9\ftech\fcharset2\fprq2 Symbol;}
+}
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Analysis of Subjects With Specific Adverse Events}\line\fs24{\f0 (Incidence > 5 Subjects in One or More Treatment Groups)}\line\fs24{\f0 ASaT}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Drug High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Drug Low Dose}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE DERMATITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8.86}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 11.69}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE ERYTHEMA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 18.99}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15.58}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE IRRITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 11.39}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 11.69}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE PRURITUS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8.7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 22.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 27.85}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 22.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 28.57}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 APPLICATION SITE VESICLES}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.59}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 COUGH}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.79}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 DIARRHOEA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 13.04}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 DIZZINESS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15.19}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 10.39}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 ERYTHEMA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 13.04}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 14.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 17.72}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 15.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 19.48}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 HEADACHE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 10.14}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.59}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 HYPERHIDROSIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 10.13}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 NASOPHARYNGITIS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.59}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 NAUSEA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.59}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 PRURITUS}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 11.59}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 26.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 32.91}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 23.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 29.87}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 RASH}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 11.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 13.92}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 13.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 16.88}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 SINUS BRADYCARDIA}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 10.13}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9.09}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 SKIN IRRITATION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.79}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 UPPER RESPIRATORY TRACT INFECTION}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8.7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3600
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4500
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5400
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6300
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7200
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8100
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 VOMITING}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 8.86}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.0}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 {\super \uc1\u8224*}This is footnote 1\line This is footnote 2}\cell
+\intbl\row\pard
+{\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Source: xxx}\par}
+
+
+
+\page
+
+
+
+
+
+\paperw12240\paperh15840
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 ANCOVA of Change from Baseline at Week 20}\line\fs24{\f0 Missing Data Approach}\line\fs24{\f0 Analysis Population}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx1174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3130
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5087
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Baseline}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Week 20}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Change from Baseline}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx1174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx1663
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx3130
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx3620
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx5087
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx5576
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx7043
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Treatment}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 N}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Mean (SD)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 N}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Mean (SD)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 N}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Mean (SD)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 LS Mean (95% CI){\super a}}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx1174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx1663
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3130
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3620
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5087
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5576
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7043
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Study Drug}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 61}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 16.6 (4.41)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 61}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -6.6 (5.95)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 61}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -7.0 (9.16)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -7.0 (-8.58, -5.38)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx1174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx1663
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3130
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3620
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5087
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5576
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7043
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 70}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 18.4 (6.34)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 70}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -9.0 (7.04)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 70}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -8.7 (8.54)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -8.7 (-10.17, -7.18)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3620
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7043
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Pairwise Comparison}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Difference in LS Mean (95% CI){\super a}}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 p-Value}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3620
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7043
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Study Drug vs. Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1.7 (-0.49, 3.88)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0.130}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Root Mean Squared Error of Change = 6.23}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 {\super a} Based on an ANCOVA model.\line ANCOVA = Analysis of Covariance, CI = Confidence Interval, LS = Least Squares, SD = Standard Deviation}\cell
+\intbl\row\pard
+{\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Source: [study999: adam-adeff]}\par}
+
+
+
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - articles/format-page.md
     - Advanced:
       - articles/advanced-group-by.md
+      - articles/assemble.md
     - Developer:
       - articles/pagination.md
       - articles/converter-setup.md


### PR DESCRIPTION
This PR:

- Renamed the "assemble" article to `assemble.md` and links it in the sidebar.
- Fixed the path situation by specifying working directory in chunk options.
- Added assembled RTF output.

The docx part is not working by default as it may require installing the package differently in the GitHub Actions workflow (`pip install rtflite[docx]`?). This installation quirk should be documented better, too.

OR maybe it should be a required dependency?