### PR TITLE
Add optional dependency instructions for uv projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,17 @@ python3 -m pip install -e .
 
 ### Optional dependencies - DOCX support
 
-Some features in rtflite require additional dependencies. To install rtflite
-with DOCX assembly support:
+Some features in rtflite require additional dependencies.
+To install rtflite with DOCX assembly support:
 
 ```bash
 pip install rtflite[docx]
+```
+
+To add rtflite as a dependency with DOCX support for projects using uv:
+
+```bash
+uv add rtflite --extra docx
 ```
 
 For rtflite developers, sync optional dependencies with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,11 +31,17 @@ python3 -m pip install -e .
 
 ### Optional dependencies - DOCX support
 
-Some features in rtflite require additional dependencies. To install rtflite
-with DOCX assembly support:
+Some features in rtflite require additional dependencies.
+To install rtflite with DOCX assembly support:
 
 ```bash
 pip install rtflite[docx]
+```
+
+To add rtflite as a dependency with DOCX support for projects using uv:
+
+```bash
+uv add rtflite --extra docx
 ```
 
 For rtflite developers, sync optional dependencies with:


### PR DESCRIPTION
This PR updates `README.md` to add instructions for developers who manage their projects with uv and want to add rtflite as a project dependency, with the optional dependencies.