### PR TITLE
Release rtflite 2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rtflite"
-version = "2.3.1"
+version = "2.4.0"
 description = "Lightweight RTF composer for Python"
 authors = [
     { name = "Yilong Zhang", email = "elong0527@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2012,7 +2012,7 @@ wheels = [
 
 [[package]]
 name = "rtflite"
-version = "2.3.1"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "narwhals" },


### PR DESCRIPTION
This PR bumps the version number to 2.4.0. The changelog was already updated.