### PR TITLE
Refactor LibreOffice conversion for reliability and 26.8 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## rtflite (development version)
+
+### Converters
+
+- Verify compatibility with the current release version of LibreOffice (26.8.0.3).
+  Isolate conversion profiles, add a configurable process timeout
+  (120 seconds by default), and preserve existing output files when
+  conversion fails (#214).
+- Support LibreOffice's `extension:filter[:options]` syntax with correct output
+  filenames. Fix `write_html()` dropping embedded images saved as sibling files
+  by LibreOffice, and retain companion resources during conversion (#214).
+- Fix relative executable paths, prefer the Windows console launcher during
+  discovery, and remove the undeclared `packaging` dependency from
+  version checks (#214).
+
 ## rtflite 2.5.4
 
 ### Bug fixes

--- a/docs/articles/advanced-group-by.md
+++ b/docs/articles/advanced-group-by.md
@@ -134,7 +134,9 @@ doc_single.write_rtf("advanced-group-by-single.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("advanced-group-by-single.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "advanced-group-by-single.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/advanced-group-by-single.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -180,7 +182,12 @@ doc_multipage.write_rtf("advanced-group-by-multipage.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("advanced-group-by-multipage.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "advanced-group-by-multipage.rtf",
+    output_dir="../pdf/",
+    format="pdf",
+    overwrite=True,
+)
 ```
 
 <embed src="../pdf/advanced-group-by-multipage.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -244,7 +251,12 @@ doc_treatment_separated.write_rtf("advanced-group-by-group-newpage.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("advanced-group-by-group-newpage.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "advanced-group-by-group-newpage.rtf",
+    output_dir="../pdf/",
+    format="pdf",
+    overwrite=True,
+)
 ```
 
 <embed src="../pdf/advanced-group-by-group-newpage.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -279,13 +291,23 @@ doc_subline = rtf.RTFDocument(
             "Severity",
             "Serious",
         ],  # Headers for remaining columns after SUBLINEBY removal
-        col_rel_width=[3, 2, 4, 2,],  
+        col_rel_width=[
+            3,
+            2,
+            4,
+            2,
+        ],
         text_format="b",
         text_justification=["l", "l", "c", "c"],
     ),
     rtf_body=rtf.RTFBody(
         subline_by=["SUBLINEBY"],  # Creates subheader rows from SUBLINEBY values
-        col_rel_width=[3, 2, 4, 2,],  
+        col_rel_width=[
+            3,
+            2,
+            4,
+            2,
+        ],
         text_justification=["l", "l", "l", "c", "c"],
     ),
     rtf_footnote=rtf.RTFFootnote(
@@ -304,7 +326,9 @@ doc_subline.write_rtf("advanced-group-by-subline.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("advanced-group-by-subline.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "advanced-group-by-subline.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/advanced-group-by-subline.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -348,14 +372,24 @@ doc_comprehensive = rtf.RTFDocument(
             "Adverse Event",
             "Severity",
         ],  # Headers for remaining columns after SUBLINEBY removal
-        col_rel_width=[3, 2, 4, 2,],  
+        col_rel_width=[
+            3,
+            2,
+            4,
+            2,
+        ],
         text_format="b",
         text_justification=["l", "c", "l", "c"],
     ),
     rtf_body=rtf.RTFBody(
         subline_by=["SUBLINEBY"],  # Creates trial/site subheaders
         group_by=["USUBJID"],  # Suppresses duplicate subject IDs
-        col_rel_width=[3, 2, 4, 2,],  
+        col_rel_width=[
+            3,
+            2,
+            4,
+            2,
+        ],
         text_justification=["l", "l", "c", "l", "c"],
     ),
     rtf_footnote=rtf.RTFFootnote(
@@ -374,7 +408,12 @@ doc_comprehensive.write_rtf("advanced-group-by-comprehensive.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("advanced-group-by-comprehensive.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "advanced-group-by-comprehensive.rtf",
+    output_dir="../pdf/",
+    format="pdf",
+    overwrite=True,
+)
 ```
 
 <embed src="../pdf/advanced-group-by-comprehensive.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -388,11 +427,13 @@ The page_by feature automatically filters these divider rows to create clean out
 
 ```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
 # Create example data with divider rows
-df = pl.DataFrame({
-    "section": ["-----", "Age", "Age"],
-    "item": ["Participant in Population", "    <60", "    >=60"],
-    "value": [55, 25, 30],
-})
+df = pl.DataFrame(
+    {
+        "section": ["-----", "Age", "Age"],
+        "item": ["Participant in Population", "    <60", "    >=60"],
+        "value": [55, 25, 30],
+    }
+)
 
 df
 ```
@@ -406,8 +447,8 @@ doc_divider = rtf.RTFDocument(
         page_by="section",
         col_rel_width=[1, 1],
         text_justification=["l", "l", "c"],
-        border_top = ["single", "", ""],
-        border_bottom = ["single", "", ""]
+        border_top=["single", "", ""],
+        border_bottom=["single", "", ""],
     ),
 )
 
@@ -416,7 +457,12 @@ doc_divider.write_rtf("advanced-group-by-divider-filtering.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("advanced-group-by-divider-filtering.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "advanced-group-by-divider-filtering.rtf",
+    output_dir="../pdf/",
+    format="pdf",
+    overwrite=True,
+)
 ```
 
 <embed src="../pdf/advanced-group-by-divider-filtering.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/articles/assemble.md
+++ b/docs/articles/assemble.md
@@ -37,7 +37,9 @@ assemble_rtf(input_files, "combined-rtf.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("combined-rtf.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "combined-rtf.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/combined-rtf.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -64,11 +66,7 @@ because `python-docx` does not evaluate those fields.
 Another example to assemble into DOCX with mixed orientation pages (portrait, landscape):
 
 ```python exec="on" source="above" session="default" workdir="docs/articles/rtf/"
-assemble_docx(
-    input_files,
-    "combined-mixed.docx",
-    landscape=[False, True]
-)
+assemble_docx(input_files, "combined-mixed.docx", landscape=[False, True])
 ```
 
 Open `combined-mixed.docx` in Word and update fields to pull in the portrait
@@ -176,7 +174,9 @@ concatenate_docx(
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("combined-python-docx.docx", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "combined-python-docx.docx", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/combined-python-docx.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -197,7 +197,12 @@ concatenate_docx(
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("combined-python-docx-mixed.docx", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "combined-python-docx-mixed.docx",
+    output_dir="../pdf/",
+    format="pdf",
+    overwrite=True,
+)
 ```
 
 <embed src="../pdf/combined-python-docx-mixed.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/articles/converter-setup.md
+++ b/docs/articles/converter-setup.md
@@ -1,7 +1,7 @@
 # Converter setup
 
-rtflite can convert RTF documents to PDF using LibreOffice.
-This guide shows how to install and use LibreOffice for PDF conversion.
+rtflite can convert RTF documents to PDF and other formats using a separately
+installed LibreOffice.
 
 ## Install LibreOffice
 
@@ -57,9 +57,7 @@ except FileNotFoundError:
 If LibreOffice is installed in a non-standard location, you can specify the path:
 
 ```python
-converter = rtf.LibreOfficeConverter(
-    executable_path="/custom/path/to/soffice"
-)
+converter = rtf.LibreOfficeConverter(executable_path="/custom/path/to/soffice")
 ```
 
 ### Supported output formats
@@ -67,13 +65,50 @@ converter = rtf.LibreOfficeConverter(
 Besides PDF, LibreOffice can convert RTF to:
 
 - `docx` - Microsoft Word format
+- `doc` - Microsoft Word 97-2003 format
 - `html` - HTML format
 - `odt` - OpenDocument Text format
+- `txt` - Plain text
 
 Example:
 ```python
 converter.convert(input_files="output.rtf", output_dir=".", format="docx")
 ```
+
+For an explicit export filter, use LibreOffice's
+`extension:filter[:options]` syntax. The returned filename uses only the extension:
+
+```python
+pdf_path = converter.convert(
+    "output.rtf", output_dir="pdfs", format="pdf:writer_pdf_Export"
+)
+text_path = converter.convert(
+    "output.rtf", output_dir="text", format="txt:Text (encoded):UTF8"
+)
+```
+
+Filter names and options are passed through to LibreOffice unchanged. See
+[LibreOffice's filter tables](https://help.libreoffice.org/latest/en-US/text/shared/guide/convertfilters.html)
+for available filters. Availability depends on the installed LibreOffice version.
+
+### Timeouts and isolated conversions
+
+Each LibreOffice process has a 120 second timeout, including the version check.
+For larger documents, increase the limit when creating the converter:
+
+```python
+converter = rtf.LibreOfficeConverter(timeout=300)
+```
+
+Use `timeout=None` to disable the limit. Failed conversions and timeouts raise
+`RuntimeError`. Existing output files are preserved if conversion fails, even
+with `overwrite=True`.
+
+Each conversion uses a temporary LibreOffice user profile, independent of open
+LibreOffice windows and other conversions. This also means personal settings
+and extensions are not used. Output files and any HTML companion resources are
+generated in a temporary directory and moved to the destination after conversion
+succeeds. The temporary files and profile are then removed.
 
 ### Batch conversion
 
@@ -82,12 +117,7 @@ Convert multiple RTF files at once:
 ```python
 files = ["file1.rtf", "file2.rtf", "file3.rtf"]
 converter = rtf.LibreOfficeConverter()
-converter.convert(
-    input_files=files,
-    output_dir="pdfs/",
-    format="pdf",
-    overwrite=True
-)
+converter.convert(input_files=files, output_dir="pdfs/", format="pdf", overwrite=True)
 ```
 
 ## CI/CD integration
@@ -133,7 +163,9 @@ RUN apt-get update && apt-get install -y libreoffice
 ## Performance tips
 
 !!! tip "Optimization suggestions"
-    1. LibreOffice starts a background process for conversions.
-    2. For batch conversions, reuse the same converter instance.
-    3. The first conversion may be slower as LibreOffice initializes.
-    4. Consider using thread-based parallel processing for large batches.
+    1. Reuse a converter instance to avoid repeating executable discovery and
+       version checks.
+    2. Each input file starts a new LibreOffice process; batch inputs are processed
+       sequentially. Reusing the converter does not keep LibreOffice running.
+    3. Concurrent calls use separate profiles. Use distinct output filenames and
+       limit concurrency to the memory available for LibreOffice processes.

--- a/docs/articles/example-ae.md
+++ b/docs/articles/example-ae.md
@@ -135,7 +135,9 @@ doc.write_rtf("example-ae-summary.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("example-ae-summary.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "example-ae-summary.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/example-ae-summary.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/articles/example-baseline.md
+++ b/docs/articles/example-baseline.md
@@ -67,7 +67,9 @@ doc.write_rtf("example-baseline-char.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("example-baseline-char.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "example-baseline-char.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/example-baseline-char.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/articles/example-efficacy.md
+++ b/docs/articles/example-efficacy.md
@@ -121,7 +121,9 @@ doc.write_rtf("example-efficacy.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("example-efficacy.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "example-efficacy.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/example-efficacy.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/articles/example-figure.md
+++ b/docs/articles/example-figure.md
@@ -58,9 +58,7 @@ for i, treatment in enumerate(treatment_groups):
 
     # Save figure
     plt.savefig(
-        f"../images/age-histogram-treatment-{i}.png",
-        dpi=300,
-        bbox_inches="tight"
+        f"../images/age-histogram-treatment-{i}.png", dpi=300, bbox_inches="tight"
     )
     plt.close()
 ```
@@ -85,7 +83,9 @@ doc_age.write_rtf("example-figure-age.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("example-figure-age.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "example-figure-age.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/example-figure-age.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -128,7 +128,9 @@ doc_multi_page.write_rtf("example-figure-multipage.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("example-figure-multipage.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "example-figure-multipage.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/example-figure-multipage.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/articles/format-page.md
+++ b/docs/articles/format-page.md
@@ -63,7 +63,9 @@ doc_default.write_rtf("format-page-default.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("format-page-default.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "format-page-default.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/format-page-default.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -92,7 +94,9 @@ doc_title_first.write_rtf("format-page-title-first.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("format-page-title-first.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "format-page-title-first.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/format-page-title-first.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -121,7 +125,9 @@ doc_footnote_first.write_rtf("format-page-footnote-first.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("format-page-footnote-first.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "format-page-footnote-first.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/format-page-footnote-first.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -150,7 +156,9 @@ doc_all_pages.write_rtf("format-page-all-pages.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("format-page-all-pages.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "format-page-all-pages.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/format-page-all-pages.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -179,7 +187,9 @@ doc_custom.write_rtf("format-page-custom.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("format-page-custom.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "format-page-custom.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/format-page-custom.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/articles/format-row.md
+++ b/docs/articles/format-row.md
@@ -55,7 +55,9 @@ doc_borders.write_rtf("row-border-styles.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("row-border-styles.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "row-border-styles.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/row-border-styles.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -86,7 +88,9 @@ doc_widths.write_rtf("row-column-widths.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("row-column-widths.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "row-column-widths.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/row-column-widths.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/articles/format-text.md
+++ b/docs/articles/format-text.md
@@ -71,7 +71,9 @@ doc_formats.write_rtf("text-format-styles.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("text-format-styles.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "text-format-styles.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/text-format-styles.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -109,7 +111,9 @@ doc_font_align.write_rtf("text-font-size-alignment.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("text-font-size-alignment.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "text-font-size-alignment.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/text-font-size-alignment.pdf" style="width:100%; height:400px" type="application/pdf">
@@ -180,7 +184,9 @@ doc_indent.write_rtf("text-indentation.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("text-indentation.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "text-indentation.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/text-indentation.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/articles/pagination.md
+++ b/docs/articles/pagination.md
@@ -68,7 +68,9 @@ def _rtf_page_break_encode(self) -> str:
 #### 3. Border logic application
 
 ```python
-def _apply_pagination_borders(self, rtf_attrs, page_info, total_pages) -> TableAttributes:
+def _apply_pagination_borders(
+    self, rtf_attrs, page_info, total_pages
+) -> TableAttributes:
     """Apply proper borders for paginated context following r2rtf design"""
     # Implements the three-tier border hierarchy
 ```
@@ -117,10 +119,8 @@ df = pl.DataFrame({"col1": range(100), "col2": range(100, 200)})
 doc = rtf.RTFDocument(
     df=df,
     # rtf_page uses defaults: portrait, nrow=40
-    rtf_column_header=[
-        rtf.RTFColumnHeader(text=["Column 1", "Column 2"])
-    ],
-    rtf_body=rtf.RTFBody()
+    rtf_column_header=[rtf.RTFColumnHeader(text=["Column 1", "Column 2"])],
+    rtf_body=rtf.RTFBody(),
 )
 
 doc.write_rtf("paginated_table.rtf")  # Automatically creates ~3 pages
@@ -133,13 +133,13 @@ doc = rtf.RTFDocument(
     df=df,
     rtf_page=rtf.RTFPage(
         orientation="landscape",  # nrow=24 by default
-        border_first="double",    # Entire table start border
-        border_last="double"      # Entire table end border
+        border_first="double",  # Entire table start border
+        border_last="double",  # Entire table end border
     ),
     rtf_body=rtf.RTFBody(
         border_first=[["single"]],  # Each page start border
-        border_last=[["single"]],   # Each page end border
-    )
+        border_last=[["single"]],  # Each page end border
+    ),
 )
 ```
 
@@ -149,7 +149,7 @@ doc = rtf.RTFDocument(
 doc = rtf.RTFDocument(
     df=small_df,  # Even small datasets can be paginated
     rtf_page=rtf.RTFPage(nrow=10),  # Force 10 rows per page
-    rtf_body=rtf.RTFBody()
+    rtf_body=rtf.RTFBody(),
 )
 ```
 

--- a/docs/articles/quickstart.md
+++ b/docs/articles/quickstart.md
@@ -346,7 +346,9 @@ doc_converted.write_rtf("text-convert.rtf")
 ```
 
 ```python exec="on" session="default" workdir="docs/articles/rtf/"
-converter.convert("text-convert.rtf", output_dir="../pdf/", format="pdf", overwrite=True)
+converter.convert(
+    "text-convert.rtf", output_dir="../pdf/", format="pdf", overwrite=True
+)
 ```
 
 <embed src="../pdf/text-convert.pdf" style="width:100%; height:400px" type="application/pdf">

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## rtflite (development version)
+
+### Converters
+
+- Verify compatibility with the current release version of LibreOffice (26.8.0.3).
+  Isolate conversion profiles, add a configurable process timeout
+  (120 seconds by default), and preserve existing output files when
+  conversion fails (#214).
+- Support LibreOffice's `extension:filter[:options]` syntax with correct output
+  filenames. Fix `write_html()` dropping embedded images saved as sibling files
+  by LibreOffice, and retain companion resources during conversion (#214).
+- Fix relative executable paths, prefer the Windows console launcher during
+  discovery, and remove the undeclared `packaging` dependency from
+  version checks (#214).
+
 ## rtflite 2.5.4
 
 ### Bug fixes

--- a/src/rtflite/convert.py
+++ b/src/rtflite/convert.py
@@ -3,10 +3,10 @@ import platform
 import re
 import shutil
 import subprocess
+import tempfile
 from collections.abc import Sequence
+from math import isfinite
 from pathlib import Path
-
-from packaging import version
 
 from .dictionary.libreoffice import DEFAULT_PATHS, MIN_VERSION
 
@@ -27,17 +27,28 @@ class LibreOfficeConverter:
         This makes it suitable for server environments and automated workflows.
     """
 
-    def __init__(self, executable_path: str | Path | None = None):
+    def __init__(
+        self,
+        executable_path: str | Path | None = None,
+        *,
+        timeout: float | None = 120,
+    ) -> None:
         """Initialize converter with optional executable path.
 
         Args:
             executable_path: Path (or executable name) to LibreOffice. If None,
                 searches standard installation locations for each platform.
+            timeout: Maximum seconds for each LibreOffice process, including
+                the version check. Defaults to 120. Use None to disable.
 
         Raises:
             FileNotFoundError: If LibreOffice executable cannot be found.
-            ValueError: If LibreOffice version is below minimum requirement.
+            ValueError: If timeout is invalid or the version cannot be parsed.
+            RuntimeError: If LibreOffice is too old, fails to start, or times out.
         """
+        if timeout is not None and (not isfinite(timeout) or timeout <= 0):
+            raise ValueError("timeout must be a positive finite number or None.")
+        self.timeout = timeout
         self.executable_path = self._resolve_executable_path(executable_path)
 
         self._verify_version()
@@ -53,15 +64,15 @@ class LibreOfficeConverter:
         executable = os.fspath(executable_path)
         expanded = os.path.expanduser(executable)
         candidate = Path(expanded)
-        candidate_str = str(candidate)
         looks_like_path = (
-            candidate.is_absolute()
-            or os.sep in candidate_str
-            or (os.altsep is not None and os.altsep in candidate_str)
+            isinstance(executable_path, Path)
+            or candidate.is_absolute()
+            or os.sep in expanded
+            or (os.altsep is not None and os.altsep in expanded)
         )
         if looks_like_path:
             if candidate.is_file():
-                return candidate
+                return candidate.absolute()
             raise FileNotFoundError(
                 f"LibreOffice executable not found at: {candidate}."
             )
@@ -69,16 +80,20 @@ class LibreOfficeConverter:
         resolved_executable = shutil.which(executable)
         if resolved_executable is None:
             raise FileNotFoundError(f"Can't find LibreOffice executable: {executable}.")
-        return Path(resolved_executable)
+        return Path(resolved_executable).absolute()
 
     def _find_executable(self) -> Path | None:
         """Find LibreOffice executable in default locations."""
-        for name in ("soffice", "libreoffice"):
+        system = platform.system()
+        # Windows needs the console launcher to capture output and wait for exit.
+        names: tuple[str, ...] = ("soffice", "libreoffice")
+        if system == "Windows":
+            names = ("soffice.com", *names)
+        for name in names:
             resolved = shutil.which(name)
             if resolved is not None:
-                return Path(resolved)
+                return Path(resolved).absolute()
 
-        system = platform.system()
         if system not in DEFAULT_PATHS:
             raise RuntimeError(f"Unsupported operating system: {system}.")
 
@@ -88,34 +103,53 @@ class LibreOfficeConverter:
                 return candidate
         return None
 
-    def _verify_version(self):
-        """Verify LibreOffice version meets minimum requirement."""
+    def _run_command(
+        self, cmd: list[str], action: str
+    ) -> subprocess.CompletedProcess[str]:
+        """Run LibreOffice with bounded execution and useful diagnostics."""
         try:
-            result = subprocess.run(
-                [str(self.executable_path), "--version"],
+            return subprocess.run(
+                cmd,
                 capture_output=True,
                 text=True,
+                errors="replace",
                 check=True,
+                timeout=self.timeout,
             )
-            version_str = result.stdout.strip()
-            # Extract version number (for example, "24.8.3.2" from the output)
-            match = re.search(r"LibreOffice (\d+\.\d+)", version_str)
-            if not match:
-                raise ValueError(
-                    f"Can't parse LibreOffice version from: {version_str}."
-                )
-
-            current_version = version.parse(match.group(1))
-            min_version = version.parse(MIN_VERSION)
-
-            if current_version < min_version:
-                raise RuntimeError(
-                    "LibreOffice version "
-                    f"{current_version} is below minimum required "
-                    f"version {min_version}."
-                )
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(
+                f"LibreOffice {action} timed out after {self.timeout} seconds."
+            ) from e
         except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"Failed to get LibreOffice version: {e}.") from e
+            raise RuntimeError(
+                f"LibreOffice {action} failed (exit code {e.returncode}):\n"
+                f"Command output: {e.stdout}\n"
+                f"Error output: {e.stderr}"
+            ) from e
+        except OSError as e:
+            raise RuntimeError(
+                f"Failed to run LibreOffice at {self.executable_path}: {e}"
+            ) from e
+
+    def _verify_version(self) -> None:
+        """Verify LibreOffice version meets minimum requirement."""
+        result = self._run_command(
+            [str(self.executable_path), "--version"], "version check"
+        )
+        version_str = result.stdout.strip()
+        match = re.search(r"LibreOffice\s+(\d+\.\d+(?:\.\d+)*)", version_str)
+        if not match:
+            raise ValueError(f"Can't parse LibreOffice version from: {version_str}.")
+
+        # LibreOffice uses numeric versions, including calendar versions (24+).
+        # Compare numerically without requiring the optional packaging library.
+        current_version = tuple(int(part) for part in match.group(1).split("."))
+        min_version = tuple(int(part) for part in MIN_VERSION.split("."))
+        if current_version < min_version:
+            raise RuntimeError(
+                f"LibreOffice version {match.group(1)} is below minimum required "
+                f"version {MIN_VERSION}."
+            )
 
     def convert(
         self,
@@ -142,16 +176,30 @@ class LibreOfficeConverter:
                 - `'html'`: HTML Document
                 - `'odt'`: OpenDocument Text
                 - `'txt'`: Plain Text
+
+                Also accepts LibreOffice's `extension:filter[:options]` syntax,
+                for example `'pdf:writer_pdf_Export'` or
+                `'txt:Text (encoded):UTF8'`. Filter names and options are passed
+                through unchanged; the extension determines the output filename.
             overwrite: If `True`, overwrites existing files in output directory.
-                If `False`, raises error if output file already exists.
+                If `False`, raises error if output file already exists. Existing
+                output is preserved if LibreOffice fails to convert the input.
 
         Returns:
             Path | Sequence[Path]: For single file input, returns Path to the
                 converted file. For multiple files, returns list of Paths.
 
         Raises:
+            FileNotFoundError: If an input file is missing or is not a file.
             FileExistsError: If output file exists and overwrite=False.
-            RuntimeError: If LibreOffice conversion fails.
+            ValueError: If format does not start with a valid file extension.
+            RuntimeError: If LibreOffice conversion fails or times out.
+
+        Note:
+            Each file is converted with a temporary, isolated LibreOffice user
+            profile, independent of an open desktop session or other conversions.
+            Personal LibreOffice settings and extensions are not used. Batch
+            inputs are processed sequentially, with a new process for each file.
 
         Examples:
             Single file conversion:
@@ -178,21 +226,26 @@ class LibreOfficeConverter:
                 print(f"Converted: {path}")
             ```
         """
-        output_dir = Path(os.path.expanduser(str(output_dir)))
-        if not output_dir.exists():
-            output_dir.mkdir(parents=True)
+        extension = format.split(":", 1)[0]
+        if not re.fullmatch(r"[A-Za-z0-9]+", extension):
+            raise ValueError(
+                "format must be an extension or extension:filter[:options], "
+                f"got {format!r}."
+            )
+        output_dir = Path(output_dir).expanduser()
+        output_dir.mkdir(parents=True, exist_ok=True)
 
         # Handle single input file
         if isinstance(input_files, (str, Path)):
-            input_path = Path(os.path.expanduser(str(input_files)))
-            if not input_path.exists():
+            input_path = Path(input_files).expanduser()
+            if not input_path.is_file():
                 raise FileNotFoundError(f"Input file not found: {input_path}.")
             return self._convert_single_file(input_path, output_dir, format, overwrite)
 
         # Handle multiple input files
-        input_paths = [Path(os.path.expanduser(str(f))) for f in input_files]
+        input_paths = [Path(f).expanduser() for f in input_files]
         for path in input_paths:
-            if not path.exists():
+            if not path.is_file():
                 raise FileNotFoundError(f"Input file not found: {path}.")
 
         return [
@@ -204,7 +257,8 @@ class LibreOfficeConverter:
         self, input_file: Path, output_dir: Path, format: str, overwrite: bool
     ) -> Path:
         """Convert a single file using LibreOffice."""
-        output_file = output_dir / f"{input_file.stem}.{format}"
+        extension = format.split(":", 1)[0]
+        output_file = output_dir / f"{input_file.stem}.{extension}"
 
         if output_file.exists() and not overwrite:
             raise FileExistsError(
@@ -212,33 +266,51 @@ class LibreOfficeConverter:
                 "Use overwrite=True to force."
             )
 
-        cmd = [
-            str(self.executable_path),
-            "--invisible",
-            "--headless",
-            "--nologo",
-            "--convert-to",
-            format,
-            "--outdir",
-            str(output_dir),
-            str(input_file),
-        ]
-
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-
-            if not output_file.exists():
+        # Stage output so an old file cannot be mistaken for a successful export.
+        # Keep it on the destination filesystem for the final file replacement.
+        with tempfile.TemporaryDirectory(prefix=".rtflite-", dir=output_dir) as tmpdir:
+            work_dir = Path(tmpdir).resolve()
+            converted_dir = work_dir / "output"
+            converted_dir.mkdir()
+            cmd = [
+                str(self.executable_path),
+                f"-env:UserInstallation={(work_dir / 'profile').as_uri()}",
+                "--headless",
+                "--nologo",
+                "--norestore",
+                "--convert-to",
+                format,
+                "--outdir",
+                str(converted_dir),
+                str(input_file.absolute()),
+            ]
+            result = self._run_command(cmd, "conversion")
+            converted_file = converted_dir / output_file.name
+            if not converted_file.is_file():
                 raise RuntimeError(
                     f"Conversion failed: Output file not created.\n"
                     f"Command output: {result.stdout}\n"
                     f"Error output: {result.stderr}"
                 )
 
-            return output_file
+            # Include companion files/directories created by formats such as HTML.
+            generated_paths = list(converted_dir.iterdir())
+            if not overwrite:
+                for path in generated_paths:
+                    destination = output_dir / path.name
+                    if destination.exists():
+                        raise FileExistsError(
+                            f"Output file already exists: {destination}. "
+                            "Use overwrite=True to force."
+                        )
+            for path in generated_paths:
+                if path == converted_file:
+                    continue
+                destination = output_dir / path.name
+                if path.is_dir():
+                    shutil.copytree(path, destination, dirs_exist_ok=overwrite)
+                else:
+                    path.replace(destination)
+            converted_file.replace(output_file)
 
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError(
-                f"LibreOffice conversion failed:\n"
-                f"Command output: {e.stdout}\n"
-                f"Error output: {e.stderr}"
-            ) from e
+        return output_file

--- a/src/rtflite/encode.py
+++ b/src/rtflite/encode.py
@@ -574,9 +574,9 @@ class RTFDocument(BaseModel):
             ```
 
         Note:
-            LibreOffice may create a companion directory (for example
-            `report.html_files`) for embedded resources. When present, it is moved
-            alongside the requested output path.
+            LibreOffice may create companion image files or directories for
+            embedded resources. These are saved alongside the requested output
+            path and must be kept with the HTML file.
         """
         target_path = Path(file_path).expanduser()
         target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -602,12 +602,13 @@ class RTFDocument(BaseModel):
                         f"{type(converted)!r} with value {converted!r}."
                     )
                 html_path = converted
-                resources_dir = html_path.with_name(f"{html_path.name}_files")
                 shutil.move(str(html_path), target_path)
-                if resources_dir.is_dir():
-                    shutil.move(
-                        str(resources_dir), target_path.parent / resources_dir.name
-                    )
+                for resource in Path(convert_tmpdir).iterdir():
+                    destination = target_path.parent / resource.name
+                    if resource.is_dir():
+                        shutil.copytree(resource, destination, dirs_exist_ok=True)
+                    else:
+                        shutil.move(str(resource), destination)
 
         print(target_path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def has_libreoffice() -> bool:
     """Return True when LibreOffice is available and can convert documents."""
     try:
         converter = LibreOfficeConverter()
-    except (FileNotFoundError, RuntimeError):
+    except (FileNotFoundError, ValueError, RuntimeError):
         return False
 
     # LibreOffice can report a valid version while still failing in headless

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,7 @@
 import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from zipfile import ZipFile
 
 import pytest
 
@@ -195,3 +197,54 @@ class TestLibreOfficeConverter:
         output_file = converter.convert(input_files=sample_rtf, output_dir=output_dir)
         assert output_dir.exists()
         assert output_file.exists()
+
+    @pytest.mark.parametrize(
+        "output_format",
+        [
+            "pdf:writer_pdf_Export",
+            'pdf:writer_pdf_Export:{"PageRange":{"type":"string","value":"1"}}',
+            "docx:Office Open XML Text",
+            "doc",
+            "odt",
+            "txt",
+            "txt:Text (encoded):UTF8",
+        ],
+    )
+    def test_export_filters_and_formats(self, sample_rtf, output_dir, output_format):
+        converter = LibreOfficeConverter()
+        output = converter.convert(sample_rtf, output_dir, format=output_format)
+        extension = output_format.split(":", 1)[0]
+        assert output == output_dir / f"test.{extension}"
+        content = output.read_bytes()
+        if extension == "pdf":
+            assert content.startswith(b"%PDF-")
+        elif extension == "doc":
+            assert content.startswith(bytes.fromhex("D0CF11E0A1B11AE1"))
+        elif extension in {"docx", "odt"}:
+            with ZipFile(output) as archive:
+                xml_file = "word/document.xml" if extension == "docx" else "content.xml"
+                assert b"This is a test RTF document." in archive.read(xml_file)
+        else:
+            assert "This is a test RTF document." in content.decode("utf-8-sig")
+
+    def test_concurrent_conversions(self, multiple_rtf_files, output_dir):
+        converter = LibreOfficeConverter()
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(converter.convert, path, output_dir)
+                for path in multiple_rtf_files[:2]
+            ]
+            outputs = [future.result() for future in futures]
+        assert len(set(outputs)) == 2
+        for output in outputs:
+            assert output.read_bytes().startswith(b"%PDF-")
+
+    def test_invalid_filter_preserves_existing_output(self, sample_rtf, output_dir):
+        converter = LibreOfficeConverter()
+        output = output_dir / "test.pdf"
+        output.write_bytes(b"existing output")
+        with pytest.raises(RuntimeError):
+            converter.convert(
+                sample_rtf, output_dir, format="pdf:NoSuchFilter", overwrite=True
+            )
+        assert output.read_bytes() == b"existing output"

--- a/tests/test_convert_executable_path.py
+++ b/tests/test_convert_executable_path.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -41,3 +42,28 @@ def test_init_raises_for_missing_command(monkeypatch):
         pytest.raises(FileNotFoundError),
     ):
         LibreOfficeConverter(executable_path="soffice")
+
+
+@pytest.mark.parametrize("path_input", ["./soffice", Path("soffice")])
+def test_relative_executable_is_resolved(tmp_path, monkeypatch, path_input):
+    dummy_executable = tmp_path / "soffice"
+    dummy_executable.touch()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(LibreOfficeConverter, "_verify_version", lambda self: None)
+    converter = LibreOfficeConverter(executable_path=path_input)
+    assert converter.executable_path == dummy_executable
+
+
+def test_windows_prefers_console_launcher(tmp_path, monkeypatch):
+    dummy_executable = tmp_path / "soffice.com"
+    dummy_executable.touch()
+    monkeypatch.setattr(LibreOfficeConverter, "_verify_version", lambda self: None)
+    with (
+        patch("rtflite.convert.platform.system", return_value="Windows"),
+        patch(
+            "rtflite.convert.shutil.which", return_value=str(dummy_executable)
+        ) as which,
+    ):
+        converter = LibreOfficeConverter()
+    which.assert_called_once_with("soffice.com")
+    assert converter.executable_path == dummy_executable

--- a/tests/test_convert_unit.py
+++ b/tests/test_convert_unit.py
@@ -1,0 +1,254 @@
+"""Converter regression tests that do not require LibreOffice."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+from urllib.parse import unquote, urlparse
+
+import pytest
+
+from rtflite.convert import LibreOfficeConverter
+
+
+@pytest.fixture
+def executable(tmp_path: Path) -> Path:
+    path = tmp_path / "soffice"
+    path.touch()
+    return path
+
+
+@pytest.fixture
+def converter(
+    executable: Path, monkeypatch: pytest.MonkeyPatch
+) -> LibreOfficeConverter:
+    monkeypatch.setattr(LibreOfficeConverter, "_verify_version", lambda self: None)
+    return LibreOfficeConverter(executable, timeout=5)
+
+
+@pytest.fixture
+def source(tmp_path: Path) -> Path:
+    path = tmp_path / "report.rtf"
+    path.write_text(r"{\rtf1\ansi rtflite}")
+    return path
+
+
+def export(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    """Simulate the CLI output filename, including explicit export filters."""
+    output_dir = Path(cmd[cmd.index("--outdir") + 1])
+    extension = cmd[cmd.index("--convert-to") + 1].split(":", 1)[0]
+    (output_dir / f"{Path(cmd[-1]).stem}.{extension}").write_bytes(b"new output")
+    return subprocess.CompletedProcess(cmd, 0, "converted", "")
+
+
+@pytest.mark.parametrize("version", ["7.1.0.3", "7.10.0.1", "24.8.3.2", "26.8.0.3"])
+def test_supported_versions(executable: Path, monkeypatch: pytest.MonkeyPatch, version):
+    run = Mock(
+        return_value=subprocess.CompletedProcess([], 0, f"LibreOffice {version}")
+    )
+    monkeypatch.setattr("rtflite.convert.subprocess.run", run)
+    LibreOfficeConverter(executable)
+    assert run.call_args.kwargs["timeout"] == 120
+
+
+@pytest.mark.parametrize(
+    ("version", "error", "message"),
+    [
+        ("LibreOffice 7.0.6.2", RuntimeError, "below minimum"),
+        ("unrecognized version", ValueError, "Can't parse"),
+    ],
+)
+def test_invalid_versions(executable, monkeypatch, version, error, message):
+    monkeypatch.setattr(
+        "rtflite.convert.subprocess.run",
+        Mock(return_value=subprocess.CompletedProcess([], 0, version)),
+    )
+    with pytest.raises(error, match=message):
+        LibreOfficeConverter(executable)
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("inf"), float("nan")])
+def test_invalid_timeout(executable, timeout):
+    with pytest.raises(ValueError, match="timeout"):
+        LibreOfficeConverter(executable, timeout=timeout)
+
+
+def test_version_timeout(executable, monkeypatch):
+    monkeypatch.setattr(
+        "rtflite.convert.subprocess.run",
+        Mock(side_effect=subprocess.TimeoutExpired([str(executable)], 2)),
+    )
+    with pytest.raises(RuntimeError, match="version check timed out after 2"):
+        LibreOfficeConverter(executable, timeout=2)
+
+
+@pytest.mark.parametrize(
+    "output_format",
+    ["pdf", "pdf:writer_pdf_Export", "txt:Text (encoded):UTF8"],
+)
+def test_filter_output_filename(
+    converter, source, tmp_path, monkeypatch, output_format
+):
+    run = Mock(side_effect=export)
+    monkeypatch.setattr("rtflite.convert.subprocess.run", run)
+    output_dir = tmp_path / "output"
+    output = converter.convert(source, output_dir, format=output_format)
+    assert output == output_dir / f"report.{output_format.split(':', 1)[0]}"
+    assert output.read_bytes() == b"new output"
+    cmd = run.call_args.args[0]
+    assert cmd[cmd.index("--convert-to") + 1] == output_format
+    assert run.call_args.kwargs["timeout"] == 5
+    assert list(output_dir.iterdir()) == [output]
+
+
+def test_isolated_profiles_and_absolute_paths(
+    converter: LibreOfficeConverter, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    source = Path("--report.rtf")
+    source.write_text(r"{\rtf1\ansi rtflite}")
+    profiles: list[Path] = []
+
+    def record_profile(cmd, **kwargs):
+        profile_arg = next(
+            arg for arg in cmd if arg.startswith("-env:UserInstallation=")
+        )
+        profile_uri = profile_arg.split("=", 1)[1]
+        output_dir = Path(cmd[cmd.index("--outdir") + 1])
+        profile = output_dir.parent / "profile"
+        assert profile_uri == profile.as_uri()
+        assert "%20" in profile_uri and "%23" in profile_uri
+        assert unquote(urlparse(profile_uri).path).endswith("/profile")
+        assert Path(cmd[-1]).is_absolute()
+        profiles.append(profile)
+        return export(cmd, **kwargs)
+
+    monkeypatch.setattr("rtflite.convert.subprocess.run", record_profile)
+    output_dir = Path("output # with spaces")
+    for _ in range(2):
+        output = converter.convert(source, output_dir, overwrite=True)
+        assert output == output_dir / "--report.pdf"
+    assert profiles[0] != profiles[1]
+    assert all(not profile.parent.exists() for profile in profiles)
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_missing_output_fails_even_with_stale_file(
+    converter, source, tmp_path, monkeypatch, existing
+):
+    output = tmp_path / "report.pdf"
+    if existing:
+        output.write_bytes(b"old output")
+    monkeypatch.setattr(
+        "rtflite.convert.subprocess.run",
+        Mock(
+            return_value=subprocess.CompletedProcess([], 0, "", "Could not load input")
+        ),
+    )
+    with pytest.raises(RuntimeError, match="Could not load input"):
+        converter.convert(source, tmp_path, overwrite=True)
+    if existing:
+        assert output.read_bytes() == b"old output"
+    else:
+        assert not output.exists()
+    assert not list(tmp_path.glob(".rtflite-*"))
+
+
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        (subprocess.TimeoutExpired([], 5), "conversion timed out after 5"),
+        (
+            subprocess.CalledProcessError(
+                1, [], output="export started", stderr="failed"
+            ),
+            "export started[\\s\\S]*failed",
+        ),
+        (PermissionError("not executable"), "not executable"),
+    ],
+)
+def test_process_failure_preserves_output(
+    converter, source, tmp_path, monkeypatch, error, message
+):
+    output = tmp_path / "report.pdf"
+    output.write_bytes(b"old output")
+
+    def fail(cmd, **kwargs):
+        export(cmd, **kwargs)  # A failed process may leave partial output.
+        raise error
+
+    monkeypatch.setattr("rtflite.convert.subprocess.run", fail)
+    with pytest.raises(RuntimeError, match=message):
+        converter.convert(source, tmp_path, overwrite=True)
+    assert output.read_bytes() == b"old output"
+    assert not list(tmp_path.glob(".rtflite-*"))
+
+
+def test_overwrite_requires_opt_in(converter, source, tmp_path, monkeypatch):
+    output = tmp_path / "report.pdf"
+    output.write_bytes(b"old output")
+    run = Mock(side_effect=export)
+    monkeypatch.setattr("rtflite.convert.subprocess.run", run)
+    with pytest.raises(FileExistsError):
+        converter.convert(source, tmp_path)
+    run.assert_not_called()
+    converter.convert(source, tmp_path, overwrite=True)
+    assert output.read_bytes() == b"new output"
+
+
+def test_timeout_can_be_disabled(converter, source, tmp_path, monkeypatch):
+    converter.timeout = None
+    run = Mock(side_effect=export)
+    monkeypatch.setattr("rtflite.convert.subprocess.run", run)
+    converter.convert(source, tmp_path)
+    assert run.call_args.kwargs["timeout"] is None
+
+
+def test_html_companion_files(converter, source, tmp_path, monkeypatch):
+    def export_html(cmd, **kwargs):
+        result = export(cmd, **kwargs)
+        output_dir = Path(cmd[cmd.index("--outdir") + 1])
+        (output_dir / "report_html_image.png").write_bytes(b"image")
+        resources = output_dir / "report.html_files"
+        resources.mkdir()
+        (resources / "image.png").write_bytes(b"nested image")
+        return result
+
+    monkeypatch.setattr("rtflite.convert.subprocess.run", export_html)
+    output_dir = tmp_path / "output"
+    converter.convert(source, output_dir, format="html")
+    converter.convert(source, output_dir, format="html", overwrite=True)
+    assert (output_dir / "report_html_image.png").read_bytes() == b"image"
+    assert (
+        output_dir / "report.html_files" / "image.png"
+    ).read_bytes() == b"nested image"
+    assert not list(output_dir.glob(".rtflite-*"))
+
+
+def test_companion_collision_preserves_files(converter, source, tmp_path, monkeypatch):
+    companion = tmp_path / "image.png"
+    companion.write_bytes(b"old image")
+
+    def export_html(cmd, **kwargs):
+        result = export(cmd, **kwargs)
+        output_dir = Path(cmd[cmd.index("--outdir") + 1])
+        (output_dir / companion.name).write_bytes(b"new image")
+        return result
+
+    monkeypatch.setattr("rtflite.convert.subprocess.run", export_html)
+    with pytest.raises(FileExistsError, match="image.png"):
+        converter.convert(source, tmp_path, format="html")
+    assert companion.read_bytes() == b"old image"
+    assert not (tmp_path / "report.html").exists()
+
+
+@pytest.mark.parametrize(
+    "output_format", ["", ".pdf", "../pdf", "pdf/file", "pdf\\file"]
+)
+def test_invalid_format(converter, source, tmp_path, output_format):
+    with pytest.raises(ValueError, match="format must be"):
+        converter.convert(source, tmp_path, format=output_format)
+
+
+def test_directory_input_rejected(converter, tmp_path):
+    with pytest.raises(FileNotFoundError):
+        converter.convert(tmp_path, tmp_path / "output")

--- a/tests/test_write_format.py
+++ b/tests/test_write_format.py
@@ -1,11 +1,13 @@
 from html.parser import HTMLParser
 from pathlib import Path
+from urllib.parse import unquote
 
 import polars as pl
 import pytest
+from PIL import Image
 
 from rtflite.encode import RTFDocument
-from rtflite.input import RTFBody, RTFColumnHeader, RTFTitle
+from rtflite.input import RTFBody, RTFColumnHeader, RTFFigure, RTFTitle
 from tests.conftest import (
     skip_if_no_libreoffice,
     skip_if_no_libreoffice_and_pypdf,
@@ -125,3 +127,30 @@ def test_write_export_creates_output_with_expected_content(
     assert "Sample Title" in extracted_text
     assert "alpha" in extracted_text
     assert "beta" in extracted_text
+
+
+@skip_if_no_libreoffice
+def test_write_html_retains_figure_images(tmp_path: Path):
+    image_path = tmp_path / "figure.png"
+    Image.new("RGB", (20, 20), "red").save(image_path)
+    document = RTFDocument(
+        rtf_figure=RTFFigure(figures=[str(image_path)], fig_width=1, fig_height=1)
+    )
+    output_path = tmp_path / "reports" / "figure report.html"
+    document.write_html(output_path)
+
+    class ImageSources(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self.sources: list[str] = []
+
+        def handle_starttag(self, tag, attrs) -> None:
+            if tag == "img":
+                self.sources.extend(value for name, value in attrs if name == "src")
+
+    parser = ImageSources()
+    parser.feed(output_path.read_text(encoding="utf-8"))
+    assert parser.sources
+    for source in parser.sources:
+        with Image.open(output_path.parent / unquote(source)) as image:
+            assert image.size == (20, 20)

--- a/tests/test_write_format_args.py
+++ b/tests/test_write_format_args.py
@@ -108,6 +108,7 @@ def test_write_export_uses_temp_files(
             resources_dir = out_path.with_name(f"{out_path.name}_files")
             resources_dir.mkdir()
             (resources_dir / "resource.txt").write_text("resource", encoding="utf-8")
+            (out_path.parent / "report_html_image.png").write_bytes(b"image")
         return out_path
 
     mock_instance.convert.side_effect = convert_side_effect
@@ -121,6 +122,12 @@ def test_write_export_uses_temp_files(
     assert not any(path.suffix == ".rtf" for path in output_dir.iterdir())
     if output_format == "html":
         assert (output_dir / f"{output_path.name}_files").is_dir()
+        assert (output_dir / "report_html_image.png").read_bytes() == b"image"
+
+        # Repeated writes update companion directories without nesting them.
+        getattr(sample_document, method_name)(output_path)
+        resources_dir = output_dir / f"{output_path.name}_files"
+        assert list(resources_dir.iterdir()) == [resources_dir / "resource.txt"]
 
     kwargs = mock_instance.convert.call_args.kwargs
     assert kwargs["input_files"].parent != output_dir


### PR DESCRIPTION
RTF conversion could mistake an existing output file for a successful export, share a LibreOffice desktop profile, and wait indefinitely. Explicit export filters also produced incorrect expected filenames, while `write_html()` discarded images saved beside the HTML file.

This refactor stages each export before replacing the destination, uses an isolated temporary profile, and adds a configurable 120-second process timeout. It supports LibreOffice's `extension:filter[:options]` syntax and preserves HTML companion files and directories, including on repeated writes.

Additional changes:

- Resolve relative executable paths and prefer the Windows console launcher during discovery.
- Remove the undeclared `packaging` dependency from numeric version checks, retaining the LibreOffice 7.1 minimum.
- Add regression tests and update the converter guide and changelog. Documentation Python code blocks are also formatted with Ruff.

Each conversion now uses a fresh profile, so personal LibreOffice settings and extensions are not inherited. Set `timeout=None` to disable the timeout, or increase it for larger documents.

Validation on macOS with LibreOffice 26.8.0.3:

- `uv run --all-extras pytest -q`: 490 passed, including real PDF, DOCX, DOC, HTML, ODT, and TXT exports, concurrent conversions, explicit filters and PDF options, failed overwrites, and HTML figure resources.
- `uv run --all-extras ruff check .`: passed.
- `uv run --all-extras mypy .`: passed.
- `uv run --all-extras zensical build --clean`: passed, including executable LibreOffice examples.
- `git diff --check`: passed.
