### PR TITLE
Use `uv_build` as build backend + PEP 639 `license` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
   discovery, and remove the undeclared `packaging` dependency from
   version checks (#214).
 
+### Maintenance
+
+- Replace `hatchling` with `uv_build` as the build backend and declare the MIT
+  license using the PEP 639 `license` field to eliminate the `uv build`
+  warning (#215).
+
 ## rtflite 2.5.4
 
 ### Bug fixes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,12 @@
   discovery, and remove the undeclared `packaging` dependency from
   version checks (#214).
 
+### Maintenance
+
+- Replace `hatchling` with `uv_build` as the build backend and declare the MIT
+  license using the PEP 639 `license` field to eliminate the `uv build`
+  warning (#215).
+
 ## rtflite 2.5.4
 
 ### Bug fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic>=2.0.0",
 ]
 readme = "README.md"
+license = "MIT"
 requires-python = ">= 3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -24,8 +25,6 @@ classifiers = [
 
     "Topic :: Text Processing",
     "Topic :: Office/Business :: Office Suites",
-
-    "License :: OSI Approved :: MIT License",
 
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -47,11 +46,11 @@ Issues = "https://github.com/pharmaverse/rtflite/issues"
 Changelog = "https://github.com/pharmaverse/rtflite/blob/main/CHANGELOG.md"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.12.10,<0.13.0"]
+build-backend = "uv_build"
 
-[tool.hatch.build.targets.sdist]
-exclude = [
+[tool.uv.build-backend]
+source-exclude = [
     "/docs",
     "/tests",
     "/scripts",
@@ -73,9 +72,7 @@ exclude = [
     "/.ruff_cache",
     "/.coverage",
 ]
-
-[tool.hatch.build.targets.wheel]
-exclude = [
+wheel-exclude = [
     "/docs",
     "/tests",
     "/scripts",


### PR DESCRIPTION
This PR:

- Replace hatchling with `uv_build` as the build backend.
- Use PEP 639 recommended `license` field in `pyproject.toml` to fix `uv build` warning.