### PR TITLE
Bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
           pytest --cov=rtflite --cov-report=xml
 
       # - name: Upload coverage reports to Codecov
-      #   uses: codecov/codecov-action@v4
+      #   uses: codecov/codecov-action@v7
       #   with:
       #     name: "py${{ matrix.python-version }}"
       #     token: ${{ secrets.CODECOV_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/configure-pages@v6
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: 3.x
 

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 

--- a/.github/workflows/ruff-check.yml
+++ b/.github/workflows/ruff-check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@
 
 ### Maintenance
 
-- Update GitHub Actions workflows to `actions/setup-python@v7` and refresh
-  the disabled Codecov step to `codecov/codecov-action@v7`.
 - Replace `hatchling` with `uv_build` as the build backend and declare the MIT
   license using the PEP 639 `license` field to eliminate the `uv build`
   warning (#215).
+- Update GitHub Actions workflows to `actions/setup-python@v7` and refresh
+  the disabled Codecov step to `codecov/codecov-action@v7` (#217).
 
 ## rtflite 2.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Maintenance
 
+- Update GitHub Actions workflows to `actions/setup-python@v7` and refresh
+  the disabled Codecov step to `codecov/codecov-action@v7`.
 - Replace `hatchling` with `uv_build` as the build backend and declare the MIT
   license using the PEP 639 `license` field to eliminate the `uv build`
   warning (#215).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,11 +17,11 @@
 
 ### Maintenance
 
-- Update GitHub Actions workflows to `actions/setup-python@v7` and refresh
-  the disabled Codecov step to `codecov/codecov-action@v7`.
 - Replace `hatchling` with `uv_build` as the build backend and declare the MIT
   license using the PEP 639 `license` field to eliminate the `uv build`
   warning (#215).
+- Update GitHub Actions workflows to `actions/setup-python@v7` and refresh
+  the disabled Codecov step to `codecov/codecov-action@v7` (#217).
 
 ## rtflite 2.5.4
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,8 @@
 
 ### Maintenance
 
+- Update GitHub Actions workflows to `actions/setup-python@v7` and refresh
+  the disabled Codecov step to `codecov/codecov-action@v7`.
 - Replace `hatchling` with `uv_build` as the build backend and declare the MIT
   license using the PEP 639 `license` field to eliminate the `uv build`
   warning (#215).


### PR DESCRIPTION
This PR bumps `actions/setup-python` from v6 to v7 across all 4 workflows and update the commented out Codecov action from v4 to v7.